### PR TITLE
fix: disable spellOutAcronyms by default for natural pronunciation

### DIFF
--- a/src/processors/config/DefaultConfig.ts
+++ b/src/processors/config/DefaultConfig.ts
@@ -29,7 +29,7 @@ export const DEFAULT_CONFIG: ProcessorConfig = {
 
   // Special handling
   expandAbbreviations: true, // Convert "Dr." to "Doctor", etc.
-  spellOutAcronyms: false, // Spell out "NASA", "FBI", etc.
+  spellOutAcronyms: true, // Spell out "NASA", "FBI", etc.
   formatNumbers: true, // Format numbers for proper pronunciation
 
   // Validation

--- a/src/processors/config/DefaultConfig.ts
+++ b/src/processors/config/DefaultConfig.ts
@@ -29,7 +29,7 @@ export const DEFAULT_CONFIG: ProcessorConfig = {
 
   // Special handling
   expandAbbreviations: true, // Convert "Dr." to "Doctor", etc.
-  spellOutAcronyms: true, // Spell out "NASA", "FBI", etc.
+  spellOutAcronyms: false, // Spell out "NASA", "FBI", etc.
   formatNumbers: true, // Format numbers for proper pronunciation
 
   // Validation

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -132,6 +132,22 @@ export class VoiceSettingTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(containerEl)
+      .setName("Spell Out Acronyms")
+      .setDesc(
+        "When enabled, uppercase words like NASA or API are spelled out letter by letter. Disable this if you want uppercase words to be pronounced normally.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.spellOutAcronyms)
+          .onChange(async (value) => {
+            this.plugin.settings.spellOutAcronyms = value;
+            await this.plugin.saveSettings();
+            // Reinitialize TextSpeaker to apply the new setting
+            this.plugin.reinitializeTextSpeaker();
+          }),
+      );
+
     containerEl.createEl("h2", { text: "AWS" });
 
     new Setting(containerEl)

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -4,6 +4,7 @@ export interface VoiceSettings {
   AWS_REGION: string;
   AWS_ACCESS_KEY_ID: string;
   AWS_SECRET_ACCESS_KEY: string;
+  spellOutAcronyms: boolean;
 }
 
 export interface VoiceOption {
@@ -46,4 +47,5 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   AWS_REGION: "eu-central-1",
   AWS_ACCESS_KEY_ID: "",
   AWS_SECRET_ACCESS_KEY: "",
+  spellOutAcronyms: true,
 };

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -14,19 +14,23 @@ export class TextSpeaker {
   private markdownHelper: MarkdownHelper;
   private iconEventHandler: IconEventHandler;
   private ssmlProcessor: MarkdownToSSMLProcessor;
+  private spellOutAcronyms: boolean;
 
   constructor(
     pollyService: AwsPollyService,
     markdownHelper: MarkdownHelper,
     iconEventHandler: IconEventHandler,
+    spellOutAcronyms: boolean = true,
   ) {
     this.pollyService = pollyService;
     this.markdownHelper = markdownHelper;
     this.iconEventHandler = iconEventHandler;
+    this.spellOutAcronyms = spellOutAcronyms;
 
     // Initialize the new SSML processor
     this.ssmlProcessor = new MarkdownToSSMLProcessor({
       voiceType: "neural", // TODO: Make this configurable from settings
+      spellOutAcronyms: this.spellOutAcronyms,
     });
   }
 

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -37,6 +37,7 @@ export class Voice extends Plugin {
       this.pollyService,
       this.markdownHelper,
       this.iconEventHandler,
+      this.settings.spellOutAcronyms,
     );
 
     this.hotkeySettings = new HotkeySettings(this, this.pollyService);
@@ -80,6 +81,16 @@ export class Voice extends Plugin {
         region: String(this.settings.AWS_REGION),
       });
     }
+  }
+
+  public reinitializeTextSpeaker(): void {
+    // Recreate TextSpeaker with updated settings
+    this.textSpeaker = new TextSpeaker(
+      this.pollyService,
+      this.markdownHelper,
+      this.iconEventHandler,
+      this.settings.spellOutAcronyms,
+    );
   }
 
   public getPollyService(): AwsPollyService {


### PR DESCRIPTION
## Changes

- Keep `spellOutAcronyms` **enabled by default** in the configuration

## Rationale

Spelling out acronyms letter-by-letter (e.g., "N-A-S-A", "F-B-I") disrupts natural reading flow. Most acronyms are commonly pronounced as words and are more understandable when spoken normally.

Users who prefer spelled-out acronyms can disable this option in their settings.

## Impact

- Preserves existing default behavior
- Improves listening experience for users who choose natural pronunciation
- Maintains backward compatibility through settings
