### PR TITLE
feat: speech customization settings (acronyms, code blocks, URLs, auto-save)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 
   ![tempo control](./assets/tempo.png)
 
+### Fine-Tune What Gets Spoken
+
+- **Spell Out Acronyms** – Off by default, so uppercase words like `NASA` or `API` are pronounced naturally. Enable it if you prefer them read letter by letter.
+- **Read Code Blocks** – Off by default, so fenced code blocks (Mermaid, YAML, and other code) are announced with a short placeholder. Enable it to have the code content read aloud.
+
 ### Built for Mobile
 
 - Launch playback on the Obsidian mobile app via the dedicated Voice menu item.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 
 - **Spell Out Acronyms** – Off by default, so uppercase words like `NASA` or `API` are pronounced naturally. Enable it if you prefer them read letter by letter.
 - **Read Code Blocks** – Off by default, so fenced code blocks (Mermaid, YAML, and other code) are announced with a short placeholder. Enable it to have the code content read aloud.
+- **Skip Website URLs** – Off by default, so URLs are read aloud as written. Enable it to strip website URLs (`https://…` and `www.…`) from the spoken output while keeping the surrounding text and link labels intact.
 
 ### Built for Mobile
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 
   ![voice download](./assets/voice-download.png)
 
+- Prefer a hands-off workflow? Enable **Auto-Save Audio to Note** in the settings to save and embed the MP3 automatically after every successful playback—no manual download click required. It stays off by default.
+
 - Cached audio prevents repeat synth costs until your note content changes.
 
 ### Precision Playback Controls

--- a/src/processors/MarkdownToSSMLProcessor.ts
+++ b/src/processors/MarkdownToSSMLProcessor.ts
@@ -60,6 +60,7 @@ export class MarkdownToSSMLProcessor {
         preserveLinkText: this.config.preserveLinkText,
         removeFrontmatter: this.config.removeFrontmatter,
         removeHTML: this.config.removeHTML,
+        skipUrls: this.config.skipUrls,
       };
       cleanProcessor(cleanOptions)(ast);
 

--- a/src/processors/config/DefaultConfig.ts
+++ b/src/processors/config/DefaultConfig.ts
@@ -14,6 +14,7 @@ export const DEFAULT_CONFIG: ProcessorConfig = {
   preserveLinkText: true,
   removeFrontmatter: true,
   removeHTML: true,
+  skipUrls: false, // Read website URLs aloud by default; enable to skip them
 
   // Enhancement options
   addHeadingEmphasis: true,

--- a/src/processors/config/DefaultConfig.ts
+++ b/src/processors/config/DefaultConfig.ts
@@ -29,7 +29,7 @@ export const DEFAULT_CONFIG: ProcessorConfig = {
 
   // Special handling
   expandAbbreviations: true, // Convert "Dr." to "Doctor", etc.
-  spellOutAcronyms: true, // Spell out "NASA", "FBI", etc.
+  spellOutAcronyms: false, // Pronounce "NASA", "FBI" naturally instead of letter by letter
   formatNumbers: true, // Format numbers for proper pronunciation
 
   // Validation

--- a/src/processors/pipeline/CleanProcessor.ts
+++ b/src/processors/pipeline/CleanProcessor.ts
@@ -12,7 +12,7 @@
  */
 
 import { visit, SKIP } from "unist-util-visit";
-import type { Root, Link, InlineCode, Html, Text } from "mdast";
+import type { Root, Link, Code, InlineCode, Html, Text } from "mdast";
 import type { Parent } from "unist";
 import type { CleanProcessorOptions } from "../../types/ProcessorTypes";
 
@@ -26,20 +26,22 @@ export function cleanProcessor(options: CleanProcessorOptions) {
         return;
       }
 
-      // Replace code blocks with "Code snippet" placeholder
-      if (options.removeCodeBlocks && node.type === "code") {
-        const placeholderNode: Text = {
-          type: "text",
-          value: "Code snippet.",
-        };
-        (parent as Parent).children[index] = placeholderNode;
+      // Handle fenced code blocks
+      if (node.type === "code") {
+        const codeNode = node as Code;
+        // When code blocks should be read, speak their raw content;
+        // otherwise announce them with a short placeholder.
+        const replacement: Text = options.removeCodeBlocks
+          ? { type: "text", value: "Code snippet." }
+          : { type: "text", value: codeNode.value };
+        (parent as Parent).children[index] = replacement;
         return SKIP;
       }
 
-      // Remove inline code backticks but keep the text
-      if (options.removeCodeBlocks && node.type === "inlineCode") {
+      // Remove inline code backticks but keep the text content so it is
+      // never silently dropped by the serializer
+      if (node.type === "inlineCode") {
         const inlineCodeNode = node as InlineCode;
-        // Replace with plain text node
         const textNode: Text = {
           type: "text",
           value: inlineCodeNode.value,

--- a/src/processors/pipeline/CleanProcessor.ts
+++ b/src/processors/pipeline/CleanProcessor.ts
@@ -31,9 +31,13 @@ export function cleanProcessor(options: CleanProcessorOptions) {
         const codeNode = node as Code;
         // When code blocks should be read, speak their raw content;
         // otherwise announce them with a short placeholder.
+        let codeValue = codeNode.value;
+        if (options.skipUrls) {
+          codeValue = removeUrls(codeValue);
+        }
         const replacement: Text = options.removeCodeBlocks
           ? { type: "text", value: "Code snippet." }
-          : { type: "text", value: codeNode.value };
+          : { type: "text", value: codeValue };
         (parent as Parent).children[index] = replacement;
         return SKIP;
       }
@@ -44,7 +48,9 @@ export function cleanProcessor(options: CleanProcessorOptions) {
         const inlineCodeNode = node as InlineCode;
         const textNode: Text = {
           type: "text",
-          value: inlineCodeNode.value,
+          value: options.skipUrls
+            ? removeUrls(inlineCodeNode.value)
+            : inlineCodeNode.value,
         };
         (parent as Parent).children[index] = textNode;
         return SKIP;
@@ -115,6 +121,9 @@ export function cleanProcessor(options: CleanProcessorOptions) {
         textNode.value = removeAudioEmbeds(textNode.value);
         textNode.value = cleanWikiLinks(textNode.value);
         textNode.value = removeEmojis(textNode.value);
+        if (options.skipUrls) {
+          textNode.value = removeUrls(textNode.value);
+        }
       }
     });
   };
@@ -164,6 +173,23 @@ function removeAudioEmbeds(text: string): string {
     /!\[\[([^\]]+)\.(mp3|wav|ogg|m4a|flac|aac|wma)\]\]/gi,
     "",
   );
+}
+
+/**
+ * Remove website URLs from text so they are not read aloud
+ * Strips http(s):// links as well as bare "www." links up to the next
+ * whitespace. Collapses any double spaces left behind by the removal.
+ * Examples:
+ *   "Visit https://example.com today" -> "Visit today"
+ *   "See www.example.com/path for more" -> "See for more"
+ */
+function removeUrls(text: string): string {
+  // Strip the URL, then collapse any double spaces it leaves behind. Leading
+  // and trailing spaces are kept so words stay separated from adjacent inline
+  // nodes (e.g. "A normal " + link + " link").
+  return text
+    .replace(/(?:https?:\/\/|www\.)[^\s]+/gi, "")
+    .replace(/[ \t]{2,}/g, " ");
 }
 
 /**

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -164,6 +164,20 @@ export class VoiceSettingTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(containerEl)
+      .setName("Auto-Save Audio to Note")
+      .setDesc(
+        "When enabled, the generated MP3 is automatically saved next to the note and embedded in it after each successful playback—no need to press the download button. Disabled by default.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.autoDownloadAudio)
+          .onChange(async (value) => {
+            this.plugin.settings.autoDownloadAudio = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
     containerEl.createEl("h2", { text: "AWS" });
 
     new Setting(containerEl)

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -165,6 +165,22 @@ export class VoiceSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Skip Website URLs")
+      .setDesc(
+        "When enabled, website URLs (such as https://example.com or www.example.com) are removed and not read aloud. Disabled by default.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.skipUrls)
+          .onChange(async (value) => {
+            this.plugin.settings.skipUrls = value;
+            await this.plugin.saveSettings();
+            // Reinitialize TextSpeaker to apply the new setting
+            this.plugin.reinitializeTextSpeaker();
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Auto-Save Audio to Note")
       .setDesc(
         "When enabled, the generated MP3 is automatically saved next to the note and embedded in it after each successful playback—no need to press the download button. Disabled by default.",

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -148,6 +148,22 @@ export class VoiceSettingTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(containerEl)
+      .setName("Read Code Blocks")
+      .setDesc(
+        "When enabled, fenced code blocks (such as Mermaid, YAML, or other code) are read aloud. Disable this to skip code blocks and announce them as a short placeholder instead.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.readCodeBlocks)
+          .onChange(async (value) => {
+            this.plugin.settings.readCodeBlocks = value;
+            await this.plugin.saveSettings();
+            // Reinitialize TextSpeaker to apply the new setting
+            this.plugin.reinitializeTextSpeaker();
+          }),
+      );
+
     containerEl.createEl("h2", { text: "AWS" });
 
     new Setting(containerEl)

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -7,6 +7,7 @@ export interface VoiceSettings {
   spellOutAcronyms: boolean;
   readCodeBlocks: boolean;
   autoDownloadAudio: boolean;
+  skipUrls: boolean;
   // Internal: tracks the one-time reset of the legacy spellOutAcronyms default
   acronymDefaultMigrated: boolean;
 }
@@ -54,5 +55,6 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   spellOutAcronyms: false,
   readCodeBlocks: false,
   autoDownloadAudio: false,
+  skipUrls: false,
   acronymDefaultMigrated: false,
 };

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -7,6 +7,8 @@ export interface VoiceSettings {
   spellOutAcronyms: boolean;
   readCodeBlocks: boolean;
   autoDownloadAudio: boolean;
+  // Internal: tracks the one-time reset of the legacy spellOutAcronyms default
+  acronymDefaultMigrated: boolean;
 }
 
 export interface VoiceOption {
@@ -52,4 +54,5 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   spellOutAcronyms: false,
   readCodeBlocks: false,
   autoDownloadAudio: false,
+  acronymDefaultMigrated: false,
 };

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -6,6 +6,7 @@ export interface VoiceSettings {
   AWS_SECRET_ACCESS_KEY: string;
   spellOutAcronyms: boolean;
   readCodeBlocks: boolean;
+  autoDownloadAudio: boolean;
 }
 
 export interface VoiceOption {
@@ -50,4 +51,5 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   AWS_SECRET_ACCESS_KEY: "",
   spellOutAcronyms: false,
   readCodeBlocks: false,
+  autoDownloadAudio: false,
 };

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -5,6 +5,7 @@ export interface VoiceSettings {
   AWS_ACCESS_KEY_ID: string;
   AWS_SECRET_ACCESS_KEY: string;
   spellOutAcronyms: boolean;
+  readCodeBlocks: boolean;
 }
 
 export interface VoiceOption {
@@ -47,5 +48,6 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   AWS_REGION: "eu-central-1",
   AWS_ACCESS_KEY_ID: "",
   AWS_SECRET_ACCESS_KEY: "",
-  spellOutAcronyms: true,
+  spellOutAcronyms: false,
+  readCodeBlocks: false,
 };

--- a/src/types/ProcessorTypes.ts
+++ b/src/types/ProcessorTypes.ts
@@ -15,6 +15,7 @@ export interface ProcessorConfig {
   preserveLinkText: boolean;
   removeFrontmatter: boolean;
   removeHTML: boolean;
+  skipUrls: boolean;
 
   // Enhancement options
   addHeadingEmphasis: boolean;
@@ -85,6 +86,7 @@ export interface CleanProcessorOptions {
   preserveLinkText: boolean;
   removeFrontmatter: boolean;
   removeHTML: boolean;
+  skipUrls: boolean;
 }
 
 /**

--- a/src/utils/IconEventHandler.ts
+++ b/src/utils/IconEventHandler.ts
@@ -615,6 +615,30 @@ export class IconEventHandler {
   }
 
   /**
+   * Automatically save the generated audio and embed it in the note.
+   * Called after a successful synthesis; only acts when the user enabled
+   * the auto-download setting. Stays silent on edge cases (no active file
+   * or no cached audio) to avoid noisy notices during automatic playback.
+   */
+  public async maybeAutoDownloadAudio(): Promise<void> {
+    if (!this.voice.settings.autoDownloadAudio) {
+      return;
+    }
+
+    const activeFile = this.plugin.app.workspace.getActiveFile();
+    if (!activeFile) {
+      return;
+    }
+
+    const audioBlob = this.pollyService.getLastGeneratedAudio(activeFile.path);
+    if (!audioBlob) {
+      return;
+    }
+
+    await this.audioFileManager.downloadAndEmbed(audioBlob);
+  }
+
+  /**
    * Handle download audio button click
    * Retrieves cached audio blob and saves it as MP3 file
    */

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -102,6 +102,9 @@ export class TextSpeaker {
         speed,
         activeFilePath || undefined,
       );
+
+      // Auto-save the generated audio to the note if the user enabled it
+      await this.iconEventHandler.maybeAutoDownloadAudio();
     } catch (error) {
       // Check if it was a cancellation
       if (error instanceof Error && error.name === "AbortError") {

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -15,22 +15,28 @@ export class TextSpeaker {
   private iconEventHandler: IconEventHandler;
   private ssmlProcessor: MarkdownToSSMLProcessor;
   private spellOutAcronyms: boolean;
+  private readCodeBlocks: boolean;
 
   constructor(
     pollyService: AwsPollyService,
     markdownHelper: MarkdownHelper,
     iconEventHandler: IconEventHandler,
-    spellOutAcronyms: boolean = true,
+    spellOutAcronyms: boolean = false,
+    readCodeBlocks: boolean = false,
   ) {
     this.pollyService = pollyService;
     this.markdownHelper = markdownHelper;
     this.iconEventHandler = iconEventHandler;
     this.spellOutAcronyms = spellOutAcronyms;
+    this.readCodeBlocks = readCodeBlocks;
 
     // Initialize the new SSML processor
     this.ssmlProcessor = new MarkdownToSSMLProcessor({
       voiceType: "neural", // TODO: Make this configurable from settings
       spellOutAcronyms: this.spellOutAcronyms,
+      // When code blocks should be read, keep them in the spoken output;
+      // otherwise the cleaner replaces them with a short placeholder.
+      removeCodeBlocks: !this.readCodeBlocks,
     });
   }
 

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -16,6 +16,7 @@ export class TextSpeaker {
   private ssmlProcessor: MarkdownToSSMLProcessor;
   private spellOutAcronyms: boolean;
   private readCodeBlocks: boolean;
+  private skipUrls: boolean;
 
   constructor(
     pollyService: AwsPollyService,
@@ -23,12 +24,14 @@ export class TextSpeaker {
     iconEventHandler: IconEventHandler,
     spellOutAcronyms: boolean = false,
     readCodeBlocks: boolean = false,
+    skipUrls: boolean = false,
   ) {
     this.pollyService = pollyService;
     this.markdownHelper = markdownHelper;
     this.iconEventHandler = iconEventHandler;
     this.spellOutAcronyms = spellOutAcronyms;
     this.readCodeBlocks = readCodeBlocks;
+    this.skipUrls = skipUrls;
 
     // Initialize the new SSML processor
     this.ssmlProcessor = new MarkdownToSSMLProcessor({
@@ -37,6 +40,8 @@ export class TextSpeaker {
       // When code blocks should be read, keep them in the spoken output;
       // otherwise the cleaner replaces them with a short placeholder.
       removeCodeBlocks: !this.readCodeBlocks,
+      // When enabled, website URLs are stripped from the spoken output.
+      skipUrls: this.skipUrls,
     });
   }
 

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -39,6 +39,7 @@ export class Voice extends Plugin {
       this.iconEventHandler,
       this.settings.spellOutAcronyms,
       this.settings.readCodeBlocks,
+      this.settings.skipUrls,
     );
 
     this.hotkeySettings = new HotkeySettings(this, this.pollyService);
@@ -103,6 +104,7 @@ export class Voice extends Plugin {
       this.iconEventHandler,
       this.settings.spellOutAcronyms,
       this.settings.readCodeBlocks,
+      this.settings.skipUrls,
     );
   }
 

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -38,6 +38,7 @@ export class Voice extends Plugin {
       this.markdownHelper,
       this.iconEventHandler,
       this.settings.spellOutAcronyms,
+      this.settings.readCodeBlocks,
     );
 
     this.hotkeySettings = new HotkeySettings(this, this.pollyService);
@@ -90,6 +91,7 @@ export class Voice extends Plugin {
       this.markdownHelper,
       this.iconEventHandler,
       this.settings.spellOutAcronyms,
+      this.settings.readCodeBlocks,
     );
   }
 

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -61,6 +61,17 @@ export class Voice extends Plugin {
 
   async loadSettings() {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+
+    // One-time migration: versions up to 1.7.3 shipped spellOutAcronyms with a
+    // stale `true` default that got persisted on any settings change. Reset it
+    // to `false` once so acronyms are pronounced naturally by default, then
+    // remember we did so—this way users can still re-enable it deliberately
+    // without it being reset again on the next load.
+    if (!this.settings.acronymDefaultMigrated) {
+      this.settings.spellOutAcronyms = false;
+      this.settings.acronymDefaultMigrated = true;
+      await this.saveSettings();
+    }
   }
 
   async saveSettings() {


### PR DESCRIPTION
## Summary

Adds several user-configurable settings to control how notes are read aloud, plus a fix so acronyms are no longer spelled out by default.

## Changes

### 🔤 Acronym spell-out disabled by default
- `spellOutAcronyms` now defaults to `false`, so uppercase words like `NASA` or `API` are pronounced naturally instead of letter by letter.
- Added a **one-time migration** in `loadSettings`: versions up to 1.7.3 persisted a stale `true` value on any settings change, so simply lowering the default would not have flipped existing installs. The migration resets the stale value to `false` once and records that it ran, so users can still deliberately re-enable it afterwards.

### 💻 "Read Code Blocks" toggle (default: off)
- When off, fenced code blocks (Mermaid, YAML, etc.) are announced with a short "Code snippet." placeholder (previous behavior).
- When on, the raw code content is read aloud.
- Inline code is now always kept as text so it is no longer silently dropped by the serializer.

### 🔗 "Skip Website URLs" toggle (default: off)
- When on, `https://…` and `www.…` URLs are stripped from the spoken output while the surrounding text and markdown link labels stay intact.
- Applied to plain text, flattened autolinks, inline code, and read-aloud code blocks. Word spacing is preserved (only the URL is removed; double spaces are collapsed).

### 💾 "Auto-Save Audio to Note" toggle (default: off)
- When on, the generated MP3 is automatically saved next to the note and embedded after each successful playback — no manual download click required.
- Reuses the existing `AudioFileManager` download/embed flow via `IconEventHandler.maybeAutoDownloadAudio`, triggered from `TextSpeaker` once synthesis succeeds. Stays silent on edge cases.

## Defaults

All new toggles default to **off**, preserving current behavior. The only behavioral change out of the box is that acronyms are now pronounced naturally.

## Testing

- `npm run build`, `npm run lint:check`, `npm run format:check` — all pass
- `npm test` — 26/26 tests pass (incl. AWS Polly integration tests)
- CI green on the latest commit (Code Quality & Build Validation + AWS Polly Tests)
- URL stripping verified against real example URLs through the full pipeline

https://claude.ai/code/session_01S1rnTSTSoJn48aGWsCmmuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1rnTSTSoJn48aGWsCmmuh)_