### PR TITLE
feat: configurable rewind/fast-forward interval + Obsidian plugin scan fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ jobs:
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -143,6 +147,15 @@ jobs:
 
           echo "✅ Plugin structure is valid"
           echo "artifact_ready=true" >> $GITHUB_ENV
+
+      - name: Attest build provenance for release assets
+        if: env.tag_exists == 'false' && env.artifact_ready == 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
 
       - name: Create GitHub release
         if: env.tag_exists == 'false' && env.artifact_ready == 'true'

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Pick **AWS Polly** or **ElevenLabs** from the **Speech Provider** dropdown in se
   ![status bar controls](./assets/status-bar-complete.png)
 
 - Use rewind/fast-forward controls and on-the-fly tempo changes for quick navigation.
+- Set how far the rewind and fast-forward controls jump—configure each independently from 1 to 60 seconds in settings (defaults to 3 seconds).
 
 ### Personalize the Voice
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import process from "process";
-import builtins from "builtin-modules";
+import { builtinModules as builtins } from "node:module";
 
 const banner =
 `/*
@@ -15,7 +15,7 @@ const context = await esbuild.context({
 	banner: {
 		js: banner,
 	},
-	entryPoints: ["main.ts"],
+	entryPoints: ["src/main.ts"],
 	bundle: true,
 	external: [
 		"obsidian",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voice",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voice",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "remark-frontmatter": "^5.0.0",
@@ -24,8 +24,6 @@
         "@types/unist": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "8.46.3",
         "@typescript-eslint/parser": "8.46.3",
-        "builtin-modules": "5.2.0",
-        "dotenv": "17.4.2",
         "esbuild": "0.28.1",
         "eslint": "9.39.1",
         "eslint-plugin-obsidianmd": "^0.3.0",
@@ -3538,19 +3536,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/builtin-modules": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.2.0.tgz",
-      "integrity": "sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -4029,19 +4014,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "@types/unist": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "8.46.3",
     "@typescript-eslint/parser": "8.46.3",
-    "builtin-modules": "5.2.0",
-    "dotenv": "17.4.2",
     "esbuild": "0.28.1",
     "eslint": "9.39.1",
     "eslint-plugin-obsidianmd": "^0.3.0",

--- a/src/service/BaseSpeechService.ts
+++ b/src/service/BaseSpeechService.ts
@@ -14,6 +14,11 @@ import type {
   CredentialValidationResult,
 } from "./SpeechProvider";
 import type { VoiceSettings, VoiceOption } from "../settings/VoiceSettings";
+import {
+  DEFAULT_SKIP_SECONDS,
+  MIN_SKIP_SECONDS,
+  MAX_SKIP_SECONDS,
+} from "../settings/VoiceSettings";
 
 export abstract class BaseSpeechService implements SpeechProvider {
   protected audio: HTMLAudioElement;
@@ -27,6 +32,9 @@ export abstract class BaseSpeechService implements SpeechProvider {
   protected lastGeneratedAudioFilePath: string | null = null;
   // Request lock mechanism - prevents concurrent operations
   protected currentRequestId: string | null = null;
+  // How many seconds the rewind / fast-forward controls jump
+  protected rewindSeconds: number = DEFAULT_SKIP_SECONDS;
+  protected forwardSeconds: number = DEFAULT_SKIP_SECONDS;
 
   constructor(voice: string, speed?: number) {
     this.voice = voice;
@@ -109,7 +117,10 @@ export abstract class BaseSpeechService implements SpeechProvider {
 
   rewindAudio(): void {
     if (this.audio && !isNaN(this.audio.duration)) {
-      this.audio.currentTime = Math.max(0, this.audio.currentTime - 3);
+      this.audio.currentTime = Math.max(
+        0,
+        this.audio.currentTime - this.rewindSeconds,
+      );
     }
   }
 
@@ -117,9 +128,37 @@ export abstract class BaseSpeechService implements SpeechProvider {
     if (this.audio && !isNaN(this.audio.duration)) {
       this.audio.currentTime = Math.min(
         this.audio.duration,
-        this.audio.currentTime + 3,
+        this.audio.currentTime + this.forwardSeconds,
       );
     }
+  }
+
+  // --- Skip interval (rewind / fast-forward) ---
+
+  setRewindSeconds(seconds: number): void {
+    this.rewindSeconds = this.clampSkipSeconds(seconds);
+  }
+
+  setForwardSeconds(seconds: number): void {
+    this.forwardSeconds = this.clampSkipSeconds(seconds);
+  }
+
+  getRewindSeconds(): number {
+    return this.rewindSeconds;
+  }
+
+  getForwardSeconds(): number {
+    return this.forwardSeconds;
+  }
+
+  private clampSkipSeconds(seconds: number): number {
+    if (!Number.isFinite(seconds)) {
+      return DEFAULT_SKIP_SECONDS;
+    }
+    return Math.min(
+      MAX_SKIP_SECONDS,
+      Math.max(MIN_SKIP_SECONDS, Math.round(seconds)),
+    );
   }
 
   // --- Speed ---

--- a/src/service/SpeechProvider.ts
+++ b/src/service/SpeechProvider.ts
@@ -43,6 +43,12 @@ export interface SpeechProvider {
   rewindAudio(): void;
   fastForwardAudio(): void;
 
+  // Skip interval (seconds) for rewind / fast-forward
+  setRewindSeconds(seconds: number): void;
+  setForwardSeconds(seconds: number): void;
+  getRewindSeconds(): number;
+  getForwardSeconds(): number;
+
   // Speed
   setSpeed(speed: number): number;
   getSpeed(): number;

--- a/src/service/SpeechProviderFactory.ts
+++ b/src/service/SpeechProviderFactory.ts
@@ -11,24 +11,32 @@ import { ElevenLabsService } from "./ElevenLabsService";
  * Create the speech provider selected in settings.
  */
 export function createSpeechProvider(settings: VoiceSettings): SpeechProvider {
+  let provider: SpeechProvider;
+
   if (settings.TTS_PROVIDER === "elevenlabs") {
-    return new ElevenLabsService(
+    provider = new ElevenLabsService(
       settings.ELEVENLABS_API_KEY,
       settings.ELEVENLABS_VOICE,
       settings.ELEVENLABS_MODEL,
       Number(settings.SPEED),
     );
+  } else {
+    provider = new AwsPollyService(
+      {
+        credentials: {
+          accessKeyId: String(settings.AWS_ACCESS_KEY_ID),
+          secretAccessKey: String(settings.AWS_SECRET_ACCESS_KEY),
+        },
+        region: String(settings.AWS_REGION),
+      },
+      settings.VOICE,
+      Number(settings.SPEED),
+    );
   }
 
-  return new AwsPollyService(
-    {
-      credentials: {
-        accessKeyId: String(settings.AWS_ACCESS_KEY_ID),
-        secretAccessKey: String(settings.AWS_SECRET_ACCESS_KEY),
-      },
-      region: String(settings.AWS_REGION),
-    },
-    settings.VOICE,
-    Number(settings.SPEED),
-  );
+  // Apply playback preferences that aren't part of the constructor
+  provider.setRewindSeconds(settings.rewindSeconds);
+  provider.setForwardSeconds(settings.forwardSeconds);
+
+  return provider;
 }

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -1,6 +1,10 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import { Voice } from "../utils/VoicePlugin";
-import { ELEVENLABS_MODELS } from "./VoiceSettings";
+import {
+  ELEVENLABS_MODELS,
+  MIN_SKIP_SECONDS,
+  MAX_SKIP_SECONDS,
+} from "./VoiceSettings";
 import { createSpeechProvider } from "../service/SpeechProviderFactory";
 
 export class VoiceSettingTab extends PluginSettingTab {
@@ -136,6 +140,38 @@ export class VoiceSettingTab extends PluginSettingTab {
 
             // Add directional indicators
             this.addSliderDirectionalIndicators(slider.sliderEl);
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Rewind interval")
+      .setDesc(
+        `How many seconds the rewind control jumps back (${MIN_SKIP_SECONDS}–${MAX_SKIP_SECONDS}s).`,
+      )
+      .addSlider((slider) =>
+        slider
+          .setLimits(MIN_SKIP_SECONDS, MAX_SKIP_SECONDS, 1)
+          .setValue(this.plugin.settings.rewindSeconds)
+          .onChange(async (value) => {
+            this.plugin.settings.rewindSeconds = value;
+            await this.plugin.saveSettings();
+            this.plugin.updateSkipIntervals();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Fast-forward interval")
+      .setDesc(
+        `How many seconds the fast-forward control jumps ahead (${MIN_SKIP_SECONDS}–${MAX_SKIP_SECONDS}s).`,
+      )
+      .addSlider((slider) =>
+        slider
+          .setLimits(MIN_SKIP_SECONDS, MAX_SKIP_SECONDS, 1)
+          .setValue(this.plugin.settings.forwardSeconds)
+          .onChange(async (value) => {
+            this.plugin.settings.forwardSeconds = value;
+            await this.plugin.saveSettings();
+            this.plugin.updateSkipIntervals();
           }),
       );
 

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -27,6 +27,24 @@ export class VoiceSettingTab extends PluginSettingTab {
     }
   }
 
+  /** Human-readable tempo label, e.g. "1.0× · normal" or "1.3× · 30% faster". */
+  private formatTempoValue(speed: number): string {
+    const rounded = Math.round(speed * 10) / 10;
+    return `${rounded.toFixed(1)}× · ${this.formatSpeedText(rounded)}`;
+  }
+
+  /** Seconds label, e.g. "3s". */
+  private formatSecondsValue(seconds: number): string {
+    return `${seconds}s`;
+  }
+
+  /** Append a live value readout to a slider setting's control row. */
+  private appendSliderValue(setting: Setting, text: string): HTMLElement {
+    const valueEl = setting.controlEl.createSpan({ cls: "voice-slider-value" });
+    valueEl.setText(text);
+    return valueEl;
+  }
+
   private addSliderDirectionalIndicators(sliderEl: HTMLElement): void {
     // Wrap the slider with directional indicators (styling lives in styles.css)
     const sliderContainer = sliderEl.parentElement;
@@ -98,82 +116,87 @@ export class VoiceSettingTab extends PluginSettingTab {
         });
       });
 
-    new Setting(containerEl)
+    const tempoSetting = new Setting(containerEl)
       .setName("Tempo")
       .setDesc(
         "Set a preferred reading tempo for pleasant and comfortable audio playback.",
-      )
-      .addSlider((slider) =>
-        slider
-          .setLimits(0.5, 1.9, 0.1)
-          .setValue(
-            this.plugin.settings.SPEED ||
-              this.plugin.getSpeechProvider().getSpeed(),
-          )
-          .onChange(async (value) => {
-            // Round to nearest 0.1 for clean values
-            const roundedValue = Math.round(value * 10) / 10;
-            this.plugin.settings.SPEED = roundedValue;
-            await this.plugin.saveSettings();
-            this.plugin.getSpeechProvider().setSpeed(roundedValue);
-
-            // Update the status bar speed display
-            this.plugin.iconEventHandler.updateSpeedDisplayFromSettings();
-
-            // Update the tooltip text with speed description
-            const speedText = this.formatSpeedText(roundedValue);
-            slider.sliderEl.setAttribute(
-              "title",
-              `${roundedValue}x - ${speedText}`,
-            );
-          })
-          .then((slider) => {
-            // Set initial tooltip text
-            const currentSpeed =
-              this.plugin.settings.SPEED ||
-              this.plugin.getSpeechProvider().getSpeed();
-            const speedText = this.formatSpeedText(currentSpeed);
-            slider.sliderEl.setAttribute(
-              "title",
-              `${currentSpeed}x - ${speedText}`,
-            );
-
-            // Add directional indicators
-            this.addSliderDirectionalIndicators(slider.sliderEl);
-          }),
       );
+    let tempoValueEl: HTMLElement;
+    tempoSetting.addSlider((slider) =>
+      slider
+        .setLimits(0.5, 1.9, 0.1)
+        .setValue(
+          this.plugin.settings.SPEED ||
+            this.plugin.getSpeechProvider().getSpeed(),
+        )
+        .onChange(async (value) => {
+          // Round to nearest 0.1 for clean values
+          const roundedValue = Math.round(value * 10) / 10;
+          this.plugin.settings.SPEED = roundedValue;
+          await this.plugin.saveSettings();
+          this.plugin.getSpeechProvider().setSpeed(roundedValue);
 
-    new Setting(containerEl)
+          // Update the status bar speed display
+          this.plugin.iconEventHandler.updateSpeedDisplayFromSettings();
+
+          tempoValueEl.setText(this.formatTempoValue(roundedValue));
+        })
+        .then((slider) => {
+          // Add directional indicators
+          this.addSliderDirectionalIndicators(slider.sliderEl);
+        }),
+    );
+    tempoValueEl = this.appendSliderValue(
+      tempoSetting,
+      this.formatTempoValue(
+        this.plugin.settings.SPEED ||
+          this.plugin.getSpeechProvider().getSpeed(),
+      ),
+    );
+
+    const rewindSetting = new Setting(containerEl)
       .setName("Rewind interval")
       .setDesc(
         `How many seconds the rewind control jumps back (${MIN_SKIP_SECONDS}–${MAX_SKIP_SECONDS}s).`,
-      )
-      .addSlider((slider) =>
-        slider
-          .setLimits(MIN_SKIP_SECONDS, MAX_SKIP_SECONDS, 1)
-          .setValue(this.plugin.settings.rewindSeconds)
-          .onChange(async (value) => {
-            this.plugin.settings.rewindSeconds = value;
-            await this.plugin.saveSettings();
-            this.plugin.updateSkipIntervals();
-          }),
       );
+    let rewindValueEl: HTMLElement;
+    rewindSetting.addSlider((slider) =>
+      slider
+        .setLimits(MIN_SKIP_SECONDS, MAX_SKIP_SECONDS, 1)
+        .setValue(this.plugin.settings.rewindSeconds)
+        .onChange(async (value) => {
+          this.plugin.settings.rewindSeconds = value;
+          await this.plugin.saveSettings();
+          this.plugin.updateSkipIntervals();
+          rewindValueEl.setText(this.formatSecondsValue(value));
+        }),
+    );
+    rewindValueEl = this.appendSliderValue(
+      rewindSetting,
+      this.formatSecondsValue(this.plugin.settings.rewindSeconds),
+    );
 
-    new Setting(containerEl)
+    const forwardSetting = new Setting(containerEl)
       .setName("Fast-forward interval")
       .setDesc(
         `How many seconds the fast-forward control jumps ahead (${MIN_SKIP_SECONDS}–${MAX_SKIP_SECONDS}s).`,
-      )
-      .addSlider((slider) =>
-        slider
-          .setLimits(MIN_SKIP_SECONDS, MAX_SKIP_SECONDS, 1)
-          .setValue(this.plugin.settings.forwardSeconds)
-          .onChange(async (value) => {
-            this.plugin.settings.forwardSeconds = value;
-            await this.plugin.saveSettings();
-            this.plugin.updateSkipIntervals();
-          }),
       );
+    let forwardValueEl: HTMLElement;
+    forwardSetting.addSlider((slider) =>
+      slider
+        .setLimits(MIN_SKIP_SECONDS, MAX_SKIP_SECONDS, 1)
+        .setValue(this.plugin.settings.forwardSeconds)
+        .onChange(async (value) => {
+          this.plugin.settings.forwardSeconds = value;
+          await this.plugin.saveSettings();
+          this.plugin.updateSkipIntervals();
+          forwardValueEl.setText(this.formatSecondsValue(value));
+        }),
+    );
+    forwardValueEl = this.appendSliderValue(
+      forwardSetting,
+      this.formatSecondsValue(this.plugin.settings.forwardSeconds),
+    );
 
     new Setting(containerEl)
       .setName("Spell Out Acronyms")

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -24,9 +24,19 @@ export interface VoiceSettings {
   readCodeBlocks: boolean;
   autoDownloadAudio: boolean;
   skipUrls: boolean;
+  // Playback: how many seconds the rewind/fast-forward controls jump
+  rewindSeconds: number;
+  forwardSeconds: number;
   // Internal: tracks the one-time reset of the legacy spellOutAcronyms default
   acronymDefaultMigrated: boolean;
 }
+
+/**
+ * Bounds and default for the rewind/fast-forward skip interval (seconds)
+ */
+export const MIN_SKIP_SECONDS = 1;
+export const MAX_SKIP_SECONDS = 60;
+export const DEFAULT_SKIP_SECONDS = 3;
 
 export interface VoiceOption {
   id: string;
@@ -115,5 +125,7 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   readCodeBlocks: false,
   autoDownloadAudio: false,
   skipUrls: false,
+  rewindSeconds: DEFAULT_SKIP_SECONDS,
+  forwardSeconds: DEFAULT_SKIP_SECONDS,
   acronymDefaultMigrated: false,
 };

--- a/src/utils/IconEventHandler.ts
+++ b/src/utils/IconEventHandler.ts
@@ -13,6 +13,8 @@ export class IconEventHandler {
   private ribbonIconEl: HTMLElement;
   private playPauseIconEl: HTMLElement;
   private downloadIconEl: HTMLElement;
+  private rewindIconEl: HTMLElement;
+  private fastForwardIconEl: HTMLElement;
   private speedDisplayEl: HTMLElement;
   private progressBarContainer: HTMLElement;
   private progressBar: HTMLElement;
@@ -129,6 +131,19 @@ export class IconEventHandler {
   }
 
   /**
+   * Refresh the rewind/fast-forward control tooltips to reflect the currently
+   * configured skip intervals.
+   */
+  public updateSkipTooltips(): void {
+    if (this.rewindIconEl) {
+      this.rewindIconEl.title = `Rewind ${this.voice.settings.rewindSeconds} seconds`;
+    }
+    if (this.fastForwardIconEl) {
+      this.fastForwardIconEl.title = `Fast-forward ${this.voice.settings.forwardSeconds} seconds`;
+    }
+  }
+
+  /**
    * Short display name for the current voice (provider-aware). Falls back to
    * the raw voice id when no catalog label is available.
    */
@@ -156,12 +171,12 @@ export class IconEventHandler {
     // Order: rewind, stop, slower, current speed, faster, play, fast-forward
 
     // Rewind
-    this.createStatusBarIcon(
+    this.rewindIconEl = this.createStatusBarIcon(
       "rewind",
       "rewind",
       () => this.pollyService.rewindAudio(),
       false,
-      "Rewind 3 seconds",
+      `Rewind ${this.voice.settings.rewindSeconds} seconds`,
     );
 
     // Stop
@@ -210,12 +225,12 @@ export class IconEventHandler {
     );
 
     // Fast-forward
-    this.createStatusBarIcon(
+    this.fastForwardIconEl = this.createStatusBarIcon(
       "fast-forward",
       "fast-forward",
       () => this.pollyService.fastForwardAudio(),
       false,
-      "Fast-forward 3 seconds",
+      `Fast-forward ${this.voice.settings.forwardSeconds} seconds`,
     );
 
     // Download MP3 (initially hidden)

--- a/src/utils/MobileControlBar.ts
+++ b/src/utils/MobileControlBar.ts
@@ -86,8 +86,11 @@ export class MobileControlBar {
     this.downloadIconEl.addClass("voice-hidden"); // Initially hidden
 
     // Rewind button
-    this.createControlButton(controlsWrapper, "rewind", "Rewind", () =>
-      this.pollyService.rewindAudio(),
+    this.createControlButton(
+      controlsWrapper,
+      "rewind",
+      `Rewind ${this.plugin.settings.rewindSeconds} seconds`,
+      () => this.pollyService.rewindAudio(),
     );
 
     // Stop button
@@ -151,7 +154,7 @@ export class MobileControlBar {
     this.createControlButton(
       controlsWrapper,
       "fast-forward",
-      "Fast Forward",
+      `Fast-forward ${this.plugin.settings.forwardSeconds} seconds`,
       () => this.pollyService.fastForwardAudio(),
     );
   }

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -128,6 +128,17 @@ export class Voice extends Plugin {
     this.iconEventHandler.updateVoiceDisplay();
   }
 
+  /**
+   * Apply the configured rewind/fast-forward skip intervals to the running
+   * provider and refresh the control tooltips. Called when the user changes
+   * the interval in settings (no audio interruption).
+   */
+  public updateSkipIntervals(): void {
+    this.speechProvider.setRewindSeconds(this.settings.rewindSeconds);
+    this.speechProvider.setForwardSeconds(this.settings.forwardSeconds);
+    this.iconEventHandler.updateSkipTooltips();
+  }
+
   public getSpeechProvider(): SpeechProvider {
     return this.speechProvider;
   }

--- a/styles.css
+++ b/styles.css
@@ -138,7 +138,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
 }
 
 .voice-slider-wrapper .slider {
@@ -158,6 +159,17 @@
 
 .voice-slider-indicator.right {
   text-align: left;
+}
+
+/* Live numeric readout shown next to a slider */
+.voice-slider-value {
+  margin-left: 10px;
+  min-width: 88px;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 /* --- Settings: credential validation panel --- */

--- a/styles.css
+++ b/styles.css
@@ -30,9 +30,10 @@
   animation: rotateCounterClockwise 2s linear infinite;
 }
 
-/* Utility */
-.voice-hidden {
-  display: none !important;
+/* Utility — doubled class raises specificity to win over component
+   display rules (e.g. flex buttons) via specificity rather than overrides. */
+.voice-hidden.voice-hidden {
+  display: none;
 }
 
 /* Native browser tooltips (title attribute) work best for status bar */
@@ -129,7 +130,7 @@
 
 .voice-progress-bar-container.error .voice-progress-bar {
   background: var(--text-error);
-  width: 100% !important;
+  width: 100%;
 }
 
 /* --- Settings: tempo slider indicators --- */
@@ -306,13 +307,10 @@
   align-items: center;
   gap: 2px;
   background: var(--nav-item-background);
-  border: none !important;
   padding: 1px;
 }
 
 .voice-mobile-control-btn {
-  background: var(--background-primary) !important;
-  background-color: var(--background-primary) !important;
   border: none;
   color: var(--interactive-accent);
   padding: 6px;
@@ -334,10 +332,23 @@
 }
 
 .voice-mobile-control-btn:hover {
-  background: var(--background-modifier-hover) !important;
   color: var(--interactive-accent);
   opacity: 1;
   transform: scale(1.05);
+}
+
+/* Doubled-class overrides: raise specificity above theme button styles
+   (e.g. ".some-container button") through specificity alone. */
+.voice-mobile-speed-group.voice-mobile-speed-group {
+  border: none;
+}
+
+.voice-mobile-control-btn.voice-mobile-control-btn {
+  background-color: var(--background-primary);
+}
+
+.voice-mobile-control-btn.voice-mobile-control-btn:hover {
+  background-color: var(--background-modifier-hover);
 }
 
 .voice-mobile-control-btn:hover svg {
@@ -427,7 +438,7 @@
 
 .voice-mobile-progress-container.error .voice-mobile-progress-bar {
   background: var(--text-error);
-  width: 100% !important;
+  width: 100%;
 }
 
 /* Responsive adjustments for smaller screens */

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,12 +1,44 @@
-import * as dotenv from "dotenv";
+import * as fs from "fs";
 import * as path from "path";
 
-// Load test environment variables first
-const testEnvPath = path.join(__dirname, "..", ".env.test");
-dotenv.config({ path: testEnvPath });
+/**
+ * Minimal .env loader (replaces the dotenv dependency for tests).
+ * Mirrors dotenv's default behavior: parse KEY=VALUE lines, ignore comments
+ * and blanks, strip surrounding quotes, and do NOT override variables that are
+ * already set in the environment.
+ */
+function loadEnvFile(filePath: string): void {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    const eq = line.indexOf("=");
+    if (eq === -1) {
+      continue;
+    }
+    const key = line.slice(0, eq).trim();
+    if (!key || key in process.env) {
+      continue;
+    }
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] = value;
+  }
+}
 
-// Also load default .env if it exists
-dotenv.config();
+// Load test environment variables first, then any default .env
+loadEnvFile(path.join(__dirname, "..", ".env.test"));
+loadEnvFile(path.join(__dirname, "..", ".env"));
 
 // Set up test environment
 process.env.NODE_ENV = "test";

--- a/tests/skip-interval.unit.test.ts
+++ b/tests/skip-interval.unit.test.ts
@@ -1,0 +1,123 @@
+import { AwsPollyService } from "../src/service/AwsPollyService";
+import { createSpeechProvider } from "../src/service/SpeechProviderFactory";
+import {
+  DEFAULT_SETTINGS,
+  DEFAULT_SKIP_SECONDS,
+  MIN_SKIP_SECONDS,
+  MAX_SKIP_SECONDS,
+} from "../src/settings/VoiceSettings";
+
+function makeProvider(): AwsPollyService {
+  return new AwsPollyService(
+    { credentials: { accessKeyId: "", secretAccessKey: "" }, region: "" },
+    "Stephen",
+    1.0,
+  );
+}
+
+// Give the mocked audio element a seekable timeline.
+function seekable(
+  provider: AwsPollyService,
+  currentTime: number,
+  duration = 100,
+) {
+  const audio = provider.getAudio() as unknown as {
+    currentTime: number;
+    duration: number;
+  };
+  audio.duration = duration;
+  audio.currentTime = currentTime;
+  return audio;
+}
+
+describe("Unit Tests - Configurable Skip Interval", () => {
+  describe("Defaults", () => {
+    test("rewind and forward default to 3 seconds", () => {
+      const provider = makeProvider();
+      expect(provider.getRewindSeconds()).toBe(DEFAULT_SKIP_SECONDS);
+      expect(provider.getForwardSeconds()).toBe(DEFAULT_SKIP_SECONDS);
+    });
+  });
+
+  describe("Rewind / fast-forward use configured values", () => {
+    test("rewind jumps back by the configured seconds", () => {
+      const provider = makeProvider();
+      provider.setRewindSeconds(10);
+      const audio = seekable(provider, 50);
+      provider.rewindAudio();
+      expect(audio.currentTime).toBe(40);
+    });
+
+    test("fast-forward jumps ahead by the configured seconds", () => {
+      const provider = makeProvider();
+      provider.setForwardSeconds(15);
+      const audio = seekable(provider, 50);
+      provider.fastForwardAudio();
+      expect(audio.currentTime).toBe(65);
+    });
+
+    test("rewind never goes below 0", () => {
+      const provider = makeProvider();
+      provider.setRewindSeconds(10);
+      const audio = seekable(provider, 2);
+      provider.rewindAudio();
+      expect(audio.currentTime).toBe(0);
+    });
+
+    test("fast-forward never exceeds the duration", () => {
+      const provider = makeProvider();
+      provider.setForwardSeconds(10);
+      const audio = seekable(provider, 95, 100);
+      provider.fastForwardAudio();
+      expect(audio.currentTime).toBe(100);
+    });
+  });
+
+  describe("Clamping", () => {
+    test("values below the minimum clamp up", () => {
+      const provider = makeProvider();
+      provider.setRewindSeconds(0);
+      expect(provider.getRewindSeconds()).toBe(MIN_SKIP_SECONDS);
+    });
+
+    test("values above the maximum clamp down", () => {
+      const provider = makeProvider();
+      provider.setForwardSeconds(1000);
+      expect(provider.getForwardSeconds()).toBe(MAX_SKIP_SECONDS);
+    });
+
+    test("non-finite values fall back to the default", () => {
+      const provider = makeProvider();
+      provider.setRewindSeconds(Number.NaN);
+      expect(provider.getRewindSeconds()).toBe(DEFAULT_SKIP_SECONDS);
+    });
+
+    test("fractional values are rounded", () => {
+      const provider = makeProvider();
+      provider.setForwardSeconds(7.6);
+      expect(provider.getForwardSeconds()).toBe(8);
+    });
+  });
+
+  describe("Factory applies settings", () => {
+    test("provider is created with the configured skip intervals", () => {
+      const provider = createSpeechProvider({
+        ...DEFAULT_SETTINGS,
+        rewindSeconds: 7,
+        forwardSeconds: 9,
+      });
+      expect(provider.getRewindSeconds()).toBe(7);
+      expect(provider.getForwardSeconds()).toBe(9);
+    });
+
+    test("out-of-range settings are clamped by the factory", () => {
+      const provider = createSpeechProvider({
+        ...DEFAULT_SETTINGS,
+        rewindSeconds: 0,
+        forwardSeconds: 999,
+      });
+      expect(provider.getRewindSeconds()).toBe(MIN_SKIP_SECONDS);
+      expect(provider.getForwardSeconds()).toBe(MAX_SKIP_SECONDS);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,19 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
-    "target": "ES6",
+    "target": "ES2018",
     "allowJs": true,
     "noImplicitAny": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "isolatedModules": true,
     "strictNullChecks": true,
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "lib": ["DOM", "ES5", "ES6", "ES7"]
+    "lib": ["DOM", "ES2018"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,7 +24,7 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
-"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
+"@aws-crypto/sha256-js@^5.2.0", "@aws-crypto/sha256-js@5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz"
   integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
@@ -340,7 +340,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz"
   integrity sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9", "@babel/core@^7.8.0", "@babel/core@>=7.0.0-beta.0 <8":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz"
   integrity sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==
@@ -594,135 +594,27 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@esbuild/aix-ppc64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz#7a01a8d2ec2fbb2dac78adad09b0fa781e4082be"
-  integrity sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==
+"@codemirror/state@^6.5.0", "@codemirror/state@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz"
+  integrity sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
 
-"@esbuild/android-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz#b540a27d14e4afd058496a4dbec4d3f414db110a"
-  integrity sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==
-
-"@esbuild/android-arm@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.1.tgz#704bd297de6d762de54eabbeafbf55f6756abe2f"
-  integrity sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==
-
-"@esbuild/android-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.1.tgz#d1cb166d34b0fbf0fe8ab460a5594f24a378701e"
-  integrity sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==
-
-"@esbuild/darwin-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz#1034b26457fc886368fe61bbd09f653f6afa8e54"
-  integrity sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==
-
-"@esbuild/darwin-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz#65556a432a1e4d72032d8218c1932fcca1a49772"
-  integrity sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==
-
-"@esbuild/freebsd-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz#2e61e0592f9030d7e3dae18ee25ebc535918aef6"
-  integrity sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==
-
-"@esbuild/freebsd-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz#c95ec289959ef8079c4dca817a1e2c4be66b9bd3"
-  integrity sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==
-
-"@esbuild/linux-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz#40b22175dda06182f3ee8141186c5ff304c4a717"
-  integrity sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==
-
-"@esbuild/linux-arm@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz#c09a0f67917592ac0de892a9be4d3814debd2a6c"
-  integrity sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==
-
-"@esbuild/linux-ia32@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz#a580f9c676797833891e519fc7a1337c8afd8db3"
-  integrity sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==
-
-"@esbuild/linux-loong64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz#46452cf321dc7f9e91c2fa780a56bb56e79cd68b"
-  integrity sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==
-
-"@esbuild/linux-mips64el@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz#4211b3184dd6608f53dcb22e39f5d34ee08852c8"
-  integrity sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==
-
-"@esbuild/linux-ppc64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz#697857c2a61cb9b0b6bb6652e40c1dc5e1ca8e5d"
-  integrity sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==
-
-"@esbuild/linux-riscv64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz#d192943eb146a40ac4c6497d0cf7be35b986bf08"
-  integrity sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==
-
-"@esbuild/linux-s390x@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz#acea0356da0e0ebc08f97cf7b9c2e401e1e648dc"
-  integrity sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==
+"@codemirror/view@6.38.6":
+  version "6.38.6"
+  resolved "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz"
+  integrity sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==
+  dependencies:
+    "@codemirror/state" "^6.5.0"
+    crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
 
 "@esbuild/linux-x64@0.28.1":
   version "0.28.1"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz"
   integrity sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==
-
-"@esbuild/netbsd-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz#8bcd77077a0dce3378b574fedb26d2a253b73d36"
-  integrity sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==
-
-"@esbuild/netbsd-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz#e7fb2a01e99c830c94e6623cd9fefb4c8fb58347"
-  integrity sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==
-
-"@esbuild/openbsd-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz#c52909372db8b86e2c55e05a8940033b5660a3b2"
-  integrity sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==
-
-"@esbuild/openbsd-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz#c427b9be5a64c262ff9a7eb70b5fbbaadf446c6c"
-  integrity sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==
-
-"@esbuild/openharmony-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz#dc9b147baca2e6c4b3c85571741ef4860a489097"
-  integrity sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==
-
-"@esbuild/sunos-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz#ce866d12df13c15e4c99f073a3d466f6e0649b3a"
-  integrity sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==
-
-"@esbuild/win32-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz#7468e3692d01d629d5941e5d83817bb80f9e39b4"
-  integrity sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==
-
-"@esbuild/win32-ia32@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz#a5bc0063fb2bcab6d0ed63f2a1537958bc269ec6"
-  integrity sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==
-
-"@esbuild/win32-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
-  integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
 
 "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.3.0", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.9.0"
@@ -774,7 +666,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.39.1", "@eslint/js@^9.30.1":
+"@eslint/js@^9.30.1", "@eslint/js@9.39.1":
   version "9.39.1"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz"
   integrity sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==
@@ -1010,7 +902,7 @@
     jest-haste-map "^29.7.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.7.0":
+"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz"
   integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
@@ -1031,7 +923,7 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^29.6.3":
+"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz"
   integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
@@ -1077,6 +969,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@marijn/find-cluster-break@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz"
+  integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
+
 "@microsoft/eslint-plugin-sdl@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@microsoft/eslint-plugin-sdl/-/eslint-plugin-sdl-1.1.0.tgz"
@@ -1099,7 +996,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1390,7 +1287,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@8.46.3":
+"@typescript-eslint/parser@^8.46.3", "@typescript-eslint/parser@8.46.3":
   version "8.46.3"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.3.tgz"
   integrity sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==
@@ -1418,7 +1315,7 @@
     "@typescript-eslint/types" "8.46.3"
     "@typescript-eslint/visitor-keys" "8.46.3"
 
-"@typescript-eslint/tsconfig-utils@8.46.3", "@typescript-eslint/tsconfig-utils@^8.46.3":
+"@typescript-eslint/tsconfig-utils@^8.46.3", "@typescript-eslint/tsconfig-utils@8.46.3":
   version "8.46.3"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.3.tgz"
   integrity sha512-GLupljMniHNIROP0zE7nCcybptolcH8QZfXOpCfhQDAdwJ/ZTlcaBOYebSOZotpti/3HrHSw7D3PZm75gYFsOA==
@@ -1434,7 +1331,7 @@
     debug "^4.3.4"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/types@8.46.3", "@typescript-eslint/types@^8.33.1", "@typescript-eslint/types@^8.46.3":
+"@typescript-eslint/types@^8.33.1", "@typescript-eslint/types@^8.46.3", "@typescript-eslint/types@8.46.3":
   version "8.46.3"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.3.tgz"
   integrity sha512-G7Ok9WN/ggW7e/tOf8TQYMaxgID3Iujn231hfi0Pc7ZheztIJVpO44ekY00b7akqc6nZcvregk0Jpah3kep6hA==
@@ -1455,7 +1352,7 @@
     semver "^7.6.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/utils@8.46.3", "@typescript-eslint/utils@^8.33.1":
+"@typescript-eslint/utils@^8.33.1", "@typescript-eslint/utils@8.46.3":
   version "8.46.3"
   resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.3.tgz"
   integrity sha512-VXw7qmdkucEx9WkmR3ld/u6VhRyKeiF1uxWwCy/iuNfokjJ7VhsgLSOTjsol8BunSw190zABzpwdNsze2Kpo4g==
@@ -1478,7 +1375,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.15.0, acorn@^8.5.0, acorn@^8.9.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0, acorn@^8.5.0, acorn@^8.9.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -1655,7 +1552,7 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-babel-jest@^29.7.0:
+"babel-jest@^29.0.0 || ^30.0.0", babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz"
   integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==
@@ -1746,7 +1643,14 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1, brace-expansion@^2.0.2:
+brace-expansion@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  dependencies:
+    balanced-match "^1.0.0"
+
+brace-expansion@^2.0.2:
   version "2.1.1"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz"
   integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
@@ -1760,7 +1664,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
+browserslist@^4.24.0, "browserslist@>= 4.21.0":
   version "4.27.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz"
   integrity sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==
@@ -1789,11 +1693,6 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
-builtin-modules@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.2.0.tgz"
-  integrity sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -1928,6 +1827,11 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+crelt@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz"
+  integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
+
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
@@ -2046,11 +1950,6 @@ doctrine@^2.1.0:
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
-
-dotenv@17.4.2:
-  version "17.4.2"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz"
-  integrity sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
@@ -2456,7 +2355,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-eslint@9.39.1, eslint@>=9.0.0:
+"eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9, "eslint@^9 || ^10", eslint@>=6.0.0, eslint@>=8, eslint@>=8.23.0, eslint@>=9.0.0, eslint@9.39.1:
   version "9.39.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz"
   integrity sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==
@@ -2595,7 +2494,7 @@ fast-glob@^3.3.2:
     merge2 "^1.3.0"
     micromatch "^4.0.8"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2663,7 +2562,15 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-up@^4.0.0, find-up@^4.1.0:
+find-up@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -2708,11 +2615,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -2830,7 +2732,17 @@ glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@14.0.0, globals@^14.0.0:
+globals@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
+  integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
+
+globals@^15.8.0:
+  version "15.15.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz"
+  integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
+
+globals@14.0.0:
   version "14.0.0"
   resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
@@ -2839,11 +2751,6 @@ globals@17.6.0:
   version "17.6.0"
   resolved "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz"
   integrity sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==
-
-globals@^15.8.0:
-  version "15.15.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz"
-  integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
 
 globalthis@^1.0.4:
   version "1.0.4"
@@ -3384,7 +3291,7 @@ jest-each@^29.7.0:
     jest-util "^29.7.0"
     pretty-format "^29.7.0"
 
-jest-environment-node@29.7.0, jest-environment-node@^29.7.0:
+jest-environment-node@^29.7.0, jest-environment-node@29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz"
   integrity sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==
@@ -3480,7 +3387,7 @@ jest-resolve-dependencies@^29.7.0:
     jest-regex-util "^29.6.3"
     jest-snapshot "^29.7.0"
 
-jest-resolve@^29.7.0:
+jest-resolve@*, jest-resolve@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz"
   integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
@@ -3576,7 +3483,7 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-jest-util@^29.7.0:
+"jest-util@^29.0.0 || ^30.0.0", jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz"
   integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
@@ -3624,7 +3531,7 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@29.7.0:
+"jest@^29.0.0 || ^30.0.0", jest@29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
@@ -4280,7 +4187,14 @@ minimatch@^8.0.0:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.4, minimatch@^9.0.5:
+minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
+minimatch@^9.0.5:
   version "9.0.9"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz"
   integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
@@ -4302,7 +4216,7 @@ moment@2.29.4:
   resolved "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
-ms@2.1.2, ms@^2.1.1:
+ms@^2.1.1, ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -4747,7 +4661,19 @@ resolve@^1.20.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^2.0.0-next.5, resolve@^2.0.0-next.6:
+resolve@^2.0.0-next.5:
+  version "2.0.0-next.7"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz"
+  integrity sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.2"
+    node-exports-info "^1.6.0"
+    object-keys "^1.1.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^2.0.0-next.6:
   version "2.0.0-next.7"
   resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz"
   integrity sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==
@@ -4823,7 +4749,12 @@ safe-regex@^2.1.1:
   dependencies:
     regexp-tree "~0.1.1"
 
-semver@^6.3.0, semver@^6.3.1:
+semver@^6.3.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -5075,6 +5006,11 @@ strnum@^2.2.3:
   dependencies:
     anynum "^1.0.0"
 
+style-mod@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz"
+  integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
+
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
@@ -5170,7 +5106,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.8.1, tslib@^2.6.2:
+tslib@^2.6.2, tslib@2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -5249,7 +5185,7 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.1.0"
     reflect.getprototypeof "^1.0.10"
 
-typescript-eslint@8.46.3, typescript-eslint@^8.35.1:
+typescript-eslint@^8.35.1, typescript-eslint@8.46.3:
   version "8.46.3"
   resolved "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.3.tgz"
   integrity sha512-bAfgMavTuGo+8n6/QQDVQz4tZ4f7Soqg53RbrlZQEoAltYop/XR4RAts/I0BrO3TTClTSTFJ0wYbla+P8cEWJA==
@@ -5259,15 +5195,15 @@ typescript-eslint@8.46.3, typescript-eslint@^8.35.1:
     "@typescript-eslint/typescript-estree" "8.46.3"
     "@typescript-eslint/utils" "8.46.3"
 
+"typescript@>=4.3 <7", typescript@>=4.8.4, "typescript@>=4.8.4 <6.0.0", typescript@5.9.3:
+  version "5.9.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
 typescript@5.4.5:
   version "5.4.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz"
   integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
-
-typescript@5.9.3:
-  version "5.9.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 uglify-js@^3.1.4:
   version "3.19.3"
@@ -5377,6 +5313,11 @@ vfile@^6.0.0:
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.8"
+  resolved "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
## Summary

This branch bundles two related changes on top of `main` (1.9.1).

### 1. Configurable rewind / fast-forward interval (feature)

The rewind and fast-forward controls were hard-coded to 3 seconds. They are now **user-configurable and independent**, 1–60 seconds each (default 3 — unchanged behavior out of the box).

- New `rewindSeconds` / `forwardSeconds` settings with `MIN`/`MAX`/`DEFAULT` bounds.
- `BaseSpeechService` uses and **clamps** the values (1–60, rounded, NaN→default); get/set exposed on the `SpeechProvider` interface; the factory applies them (also on provider switch).
- Two settings sliders, applied live via `Voice.updateSkipIntervals()` (no audio interruption).
- Status bar and mobile control tooltips reflect the configured seconds.
- Tests for skip behavior, 0/duration bounds, clamping, and factory application.

### 2. Obsidian plugin scan fixes (chore — no behavior change)

Resolves the warnings and "Other" items from the Obsidian community plugin review:

- **Build verification / `TFile` as `any`**: modernized `tsconfig` (drop deprecated `baseUrl`, `moduleResolution: "bundler"`, `target` ES2018, `skipLibCheck`) so a clean `tsc` no longer errors on deprecations; esbuild entry set to `src/main.ts` (previously resolved via `baseUrl`).
- **`!important` (7×)**: removed from `styles.css`; replaced with specificity (doubled class / ancestor), preserving the exact visual behavior.
- **`builtin-modules`**: replaced with Node's built-in `node:module` `builtinModules`; dependency removed.
- **`dotenv`**: replaced with a tiny built-in `.env` loader in the test setup; dependency removed. Both lockfiles (`package-lock.json`, `yarn.lock`) re-synced.
- **Missing artifact attestations**: added `actions/attest-build-provenance` for the release assets in the release workflow.

Not addressed (out of our control / expected): the `__awaiter` ES5 helpers come from the bundled AWS SDK (shipped as ES5); "Vault Read/Write" are expected disclosures.

## Testing

- `npm run build`, `npm run lint:check`, `npm run format:check` — all pass
- `npm test` — **54/54** tests pass (5 suites)
- Clean `tsc -noEmit -skipLibCheck` exits 0 (no deprecation errors)
- Both CI install paths verified: `npm ci` and `yarn install --frozen-lockfile` succeed; `npm audit` reports **0 vulnerabilities**

https://claude.ai/code/session_01S1rnTSTSoJn48aGWsCmmuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1rnTSTSoJn48aGWsCmmuh)_