### PR TITLE
Split auto-download and embed into separate toggles

### DIFF
--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -254,13 +254,27 @@ export class VoiceSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Auto-Save Audio to Note")
       .setDesc(
-        "When enabled, the generated MP3 is automatically saved next to the note and embedded in it after each successful playback—no need to press the download button. Disabled by default.",
+        "When enabled, the generated MP3 is automatically saved next to the note after each successful playback—no need to press the download button. Disabled by default.",
       )
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.autoDownloadAudio)
           .onChange(async (value) => {
             this.plugin.settings.autoDownloadAudio = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Embed Audio in Note")
+      .setDesc(
+        "When enabled, saving an MP3 also inserts an audio embed in the note. This applies to both the download button and auto-save. Turn it off to download the MP3 without embedding it. Enabled by default.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.autoEmbedAudio)
+          .onChange(async (value) => {
+            this.plugin.settings.autoEmbedAudio = value;
             await this.plugin.saveSettings();
           }),
       );

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -32,6 +32,7 @@ export interface VoiceSettings {
   spellOutAcronyms: boolean;
   readCodeBlocks: boolean;
   autoDownloadAudio: boolean;
+  autoEmbedAudio: boolean;
   skipUrls: boolean;
   // Playback: how many seconds the rewind/fast-forward controls jump
   rewindSeconds: number;
@@ -280,6 +281,9 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   spellOutAcronyms: false,
   readCodeBlocks: false,
   autoDownloadAudio: false,
+  // Embed the saved MP3 in the note. On by default so manual downloads keep
+  // their previous behaviour (save + embed). Turn off to download only.
+  autoEmbedAudio: true,
   skipUrls: false,
   rewindSeconds: DEFAULT_SKIP_SECONDS,
   forwardSeconds: DEFAULT_SKIP_SECONDS,

--- a/src/utils/AudioFileManager.ts
+++ b/src/utils/AudioFileManager.ts
@@ -130,10 +130,15 @@ export class AudioFileManager {
   }
 
   /**
-   * Download audio file and insert embed in one operation
+   * Download audio file and, when requested, insert the embed tag.
    * @param audioBlob - The audio data to save
+   * @param embed - Whether to also insert the `![[file.mp3]]` embed in the
+   *   note. Defaults to true to preserve the legacy save-and-embed behaviour.
    */
-  async downloadAndEmbed(audioBlob: Blob): Promise<void> {
+  async downloadAndEmbed(
+    audioBlob: Blob,
+    embed: boolean = true,
+  ): Promise<void> {
     try {
       const activeFile = this.app.workspace.getActiveFile();
       if (!activeFile) {
@@ -150,8 +155,10 @@ export class AudioFileManager {
         return; // Error already shown in saveAudioFile
       }
 
-      // Insert the embed tag
-      await this.insertAudioEmbed(audioFileName);
+      // Insert the embed tag only when embedding is enabled
+      if (embed) {
+        await this.insertAudioEmbed(audioFileName);
+      }
     } catch (error) {
       console.error("Error in downloadAndEmbed:", error);
       new Notice(`Error downloading audio: ${error.message}`);

--- a/src/utils/IconEventHandler.ts
+++ b/src/utils/IconEventHandler.ts
@@ -577,10 +577,11 @@ export class IconEventHandler {
   }
 
   /**
-   * Automatically save the generated audio and embed it in the note.
-   * Called after a successful synthesis; only acts when the user enabled
-   * the auto-download setting. Stays silent on edge cases (no active file
-   * or no cached audio) to avoid noisy notices during automatic playback.
+   * Automatically save the generated audio after a successful synthesis, and
+   * embed it in the note when the separate auto-embed setting is enabled.
+   * Only acts when the user enabled the auto-download setting. Stays silent on
+   * edge cases (no active file or no cached audio) to avoid noisy notices
+   * during automatic playback.
    */
   public async maybeAutoDownloadAudio(): Promise<void> {
     if (!this.voice.settings.autoDownloadAudio) {
@@ -597,7 +598,10 @@ export class IconEventHandler {
       return;
     }
 
-    await this.audioFileManager.downloadAndEmbed(audioBlob);
+    await this.audioFileManager.downloadAndEmbed(
+      audioBlob,
+      this.voice.settings.autoEmbedAudio,
+    );
   }
 
   /**
@@ -625,8 +629,11 @@ export class IconEventHandler {
         return;
       }
 
-      // Use AudioFileManager to save and embed
-      await this.audioFileManager.downloadAndEmbed(audioBlob);
+      // Use AudioFileManager to save and (optionally) embed
+      await this.audioFileManager.downloadAndEmbed(
+        audioBlob,
+        this.voice.settings.autoEmbedAudio,
+      );
     } catch (error) {
       console.error("Error downloading audio:", error);
       new Notice(`Failed to download audio: ${error.message}`);

--- a/src/utils/MobileControlBar.ts
+++ b/src/utils/MobileControlBar.ts
@@ -446,8 +446,11 @@ export class MobileControlBar {
         return;
       }
 
-      // Use AudioFileManager to save and embed
-      await this.audioFileManager.downloadAndEmbed(audioBlob);
+      // Use AudioFileManager to save and (optionally) embed
+      await this.audioFileManager.downloadAndEmbed(
+        audioBlob,
+        this.plugin.settings.autoEmbedAudio,
+      );
     } catch (error) {
       console.error("Error downloading audio:", error);
       new Notice(`Failed to download audio: ${error.message}`);


### PR DESCRIPTION
## Summary

Splits the single "Auto-Save Audio to Note" behavior into two independent toggles, so downloading an MP3 and embedding it in the note can be controlled separately. Previously the one setting always did both, with no way to download without embedding.

## Changes

- **New setting `autoEmbedAudio`** (default `true`) — "Embed Audio in Note". Governs whether saving an MP3 also inserts the `[[file.mp3]]` embed.
- **`autoDownloadAudio`** keeps its meaning (auto-save the MP3 after playback), default `false`. Its description no longer mentions embedding.
- The embed toggle applies **everywhere a save happens** — auto-save, the desktop/mobile download buttons, and the player's download button — so turning it off lets you download the MP3 without embedding it.
- `downloadAndEmbed` now takes an `embed` flag; all call sites pass the toggle.

## Compatibility

`autoEmbedAudio` defaults to `true`, so existing installs and the manual download button keep their previous save-and-embed behavior. No migration needed — merged defaults fill in the new field for existing settings.

## Verification

- `npm run build` ✓
- `npm run lint:check` ✓
- `npm run format:check` ✓
- `npm test` ✓ (8 suites, 81 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1rnTSTSoJn48aGWsCmmuh)_