### PR TITLE
Add loading feedback and provider/voice/code controls to the player

### DIFF
--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -1,10 +1,4 @@
-import {
-  ItemView,
-  WorkspaceLeaf,
-  TFile,
-  setIcon,
-  normalizePath,
-} from "obsidian";
+import { ItemView, WorkspaceLeaf, TFile, setIcon } from "obsidian";
 import type { Voice } from "../utils/VoicePlugin";
 import type { TtsProvider } from "../settings/VoiceSettings";
 import { listChapters, type ChapterFile } from "../utils/chapters";
@@ -59,6 +53,10 @@ export class VoicePlayerView extends ItemView {
   private chapters: ChapterFile[] = [];
   private repeatMode: RepeatMode = "none";
   private endedHandled = false;
+  // The generated-audio blob that has already been saved via the download
+  // button. Used to disable download once the current audio is saved, while
+  // re-enabling it as soon as a fresh synthesis produces new audio.
+  private lastDownloadedBlob: Blob | null = null;
 
   constructor(leaf: WorkspaceLeaf, plugin: Voice) {
     super(leaf);
@@ -294,7 +292,16 @@ export class VoicePlayerView extends ItemView {
    * shared download flow so behaviour matches the status bar / mobile button.
    */
   private async downloadAudio(): Promise<void> {
+    const active = this.app.workspace.getActiveFile();
+    const blob = active
+      ? this.provider().getLastGeneratedAudio(active.path)
+      : null;
     await this.plugin.iconEventHandler.handleDownloadAudio();
+    // Remember which audio we saved so the button disables until the next
+    // synthesis produces a new blob.
+    if (blob) {
+      this.lastDownloadedBlob = blob;
+    }
     this.refreshContext();
   }
 
@@ -371,7 +378,9 @@ export class VoicePlayerView extends ItemView {
 
   /**
    * Enable the download button only when there is freshly generated audio for
-   * the active note that has not already been saved as an MP3.
+   * the active note that has not already been saved via this button. A new
+   * synthesis produces a new blob, which re-enables the button; saving it
+   * disables it again.
    */
   private updateDownloadButton(): void {
     if (!this.downloadBtn) {
@@ -381,13 +390,7 @@ export class VoicePlayerView extends ItemView {
     const active = this.app.workspace.getActiveFile();
     if (active) {
       const cached = this.provider().getLastGeneratedAudio(active.path);
-      const dir = active.parent?.path ?? "";
-      const mp3Path = normalizePath(
-        dir ? `${dir}/${active.basename}.mp3` : `${active.basename}.mp3`,
-      );
-      const alreadySaved =
-        this.app.vault.getAbstractFileByPath(mp3Path) instanceof TFile;
-      enabled = cached !== null && !alreadySaved;
+      enabled = cached !== null && cached !== this.lastDownloadedBlob;
     }
     this.downloadBtn.disabled = !enabled;
     this.downloadBtn.toggleClass("is-disabled", !enabled);

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -1,5 +1,12 @@
-import { ItemView, WorkspaceLeaf, TFile, setIcon } from "obsidian";
+import {
+  ItemView,
+  WorkspaceLeaf,
+  TFile,
+  setIcon,
+  normalizePath,
+} from "obsidian";
 import type { Voice } from "../utils/VoicePlugin";
+import type { TtsProvider } from "../settings/VoiceSettings";
 import { listChapters, type ChapterFile } from "../utils/chapters";
 
 export const VIEW_TYPE_VOICE_PLAYER = "voice-player-view";
@@ -8,6 +15,14 @@ const MIN_SPEED = 0.5;
 const MAX_SPEED = 2.0;
 
 type RepeatMode = "none" | "one" | "all";
+
+/** Selectable TTS providers, mirroring the settings tab. */
+const PROVIDERS: { id: TtsProvider; label: string }[] = [
+  { id: "polly", label: "AWS Polly" },
+  { id: "elevenlabs", label: "ElevenLabs" },
+  { id: "google", label: "Google Cloud" },
+  { id: "azure", label: "Azure Speech" },
+];
 
 /**
  * VoicePlayerView - a collapsible audiobook-style player.
@@ -32,6 +47,12 @@ export class VoicePlayerView extends ItemView {
   private repeatBtn: HTMLElement;
   private speedEl: HTMLElement;
   private chaptersListEl: HTMLElement;
+  private readBtn: HTMLButtonElement;
+  private downloadBtn: HTMLButtonElement;
+  private providerSelect: HTMLSelectElement;
+  private voiceSelect: HTMLSelectElement;
+  private codeBtn: HTMLElement;
+  private loadingBarEl: HTMLElement;
 
   private isScrubbing = false;
   private currentChapterPath: string | null = null;
@@ -173,21 +194,21 @@ export class VoicePlayerView extends ItemView {
     // Secondary row: read note + speed
     const secondary = root.createDiv({ cls: "voice-player-secondary" });
 
-    const readBtn = secondary.createEl("button", {
+    this.readBtn = secondary.createEl("button", {
       cls: "voice-player-read",
       text: "Read this note",
     });
-    this.registerDomEvent(readBtn, "click", () => void this.plugin.speakText());
+    this.registerDomEvent(this.readBtn, "click", () => this.handleReadClick());
 
     // Save the generated audio as an MP3 in the note's folder so it shows up
     // as a chapter (same behaviour as the status bar / mobile download button).
-    const downloadBtn = secondary.createEl("button", {
+    this.downloadBtn = secondary.createEl("button", {
       cls: "voice-player-download",
       attr: { "aria-label": "Download as MP3" },
     });
-    setIcon(downloadBtn, "download");
+    setIcon(this.downloadBtn, "download");
     this.registerDomEvent(
-      downloadBtn,
+      this.downloadBtn,
       "click",
       () => void this.downloadAudio(),
     );
@@ -208,6 +229,34 @@ export class VoicePlayerView extends ItemView {
     setIcon(faster, "plus");
     this.registerDomEvent(faster, "click", () => this.changeSpeed(0.1));
 
+    // Options row: provider + voice selectors and the read-code-blocks toggle
+    const options = root.createDiv({ cls: "voice-player-options" });
+
+    this.providerSelect = options.createEl("select", {
+      cls: "voice-player-select dropdown",
+      attr: { "aria-label": "Speech provider" },
+    });
+    PROVIDERS.forEach((p) =>
+      this.providerSelect.createEl("option", { value: p.id, text: p.label }),
+    );
+    this.registerDomEvent(this.providerSelect, "change", () =>
+      this.changeProvider(this.providerSelect.value as TtsProvider),
+    );
+
+    this.voiceSelect = options.createEl("select", {
+      cls: "voice-player-select dropdown",
+      attr: { "aria-label": "Voice" },
+    });
+    this.registerDomEvent(this.voiceSelect, "change", () =>
+      this.changeVoice(this.voiceSelect.value),
+    );
+
+    this.codeBtn = options.createEl("button", {
+      cls: "voice-player-code",
+    });
+    setIcon(this.codeBtn, "code");
+    this.registerDomEvent(this.codeBtn, "click", () => this.toggleCodeBlocks());
+
     // Chapters
     const chapters = root.createDiv({ cls: "voice-player-chapters" });
     chapters
@@ -216,6 +265,12 @@ export class VoicePlayerView extends ItemView {
     this.chaptersListEl = chapters.createDiv({
       cls: "voice-player-chapters-list",
     });
+
+    // Loading bar (indeterminate), shown while a note is being processed.
+    this.loadingBarEl = root.createDiv({ cls: "voice-player-loading" });
+    this.loadingBarEl.createDiv({ cls: "voice-player-loading-fill" });
+
+    this.refreshControls();
   }
 
   private togglePlay(): void {
@@ -241,6 +296,101 @@ export class VoicePlayerView extends ItemView {
   private async downloadAudio(): Promise<void> {
     await this.plugin.iconEventHandler.handleDownloadAudio();
     this.refreshContext();
+  }
+
+  /** Read the current note. Ignored while a synthesis is already running. */
+  private handleReadClick(): void {
+    if (this.provider().isOperationInProgress()) {
+      return;
+    }
+    void this.plugin.speakText();
+  }
+
+  /** Switch the active TTS provider and resync the voice list. */
+  private changeProvider(provider: TtsProvider): void {
+    if (provider === this.plugin.settings.TTS_PROVIDER) {
+      return;
+    }
+    this.plugin.settings.TTS_PROVIDER = provider;
+    void this.plugin.saveSettings();
+    this.plugin.reinitializeProvider();
+    this.refreshControls();
+  }
+
+  /** Persist and apply the chosen voice for the active provider. */
+  private changeVoice(voiceId: string): void {
+    if (voiceId === this.provider().getVoice()) {
+      return;
+    }
+    void this.plugin.persistActiveVoice(voiceId);
+  }
+
+  /** Toggle whether code blocks are read aloud. */
+  private toggleCodeBlocks(): void {
+    this.plugin.settings.readCodeBlocks = !this.plugin.settings.readCodeBlocks;
+    void this.plugin.saveSettings();
+    this.plugin.reinitializeTextSpeaker();
+    this.updateCodeButton();
+  }
+
+  /** Resync the provider/voice selectors and the code-blocks toggle. */
+  private refreshControls(): void {
+    if (!this.providerSelect) {
+      return;
+    }
+    this.providerSelect.value = this.plugin.settings.TTS_PROVIDER;
+    this.populateVoiceOptions();
+    this.updateCodeButton();
+    this.updateDownloadButton();
+  }
+
+  /** Rebuild the voice dropdown from the active provider's catalog. */
+  private populateVoiceOptions(): void {
+    this.voiceSelect.empty();
+    const provider = this.provider();
+    provider.getVoiceOptions().forEach((voice) => {
+      this.voiceSelect.createEl("option", {
+        value: voice.id,
+        text: voice.label,
+      });
+    });
+    this.voiceSelect.value = provider.getVoice();
+  }
+
+  private updateCodeButton(): void {
+    if (!this.codeBtn) {
+      return;
+    }
+    const on = this.plugin.settings.readCodeBlocks;
+    this.codeBtn.toggleClass("is-active", on);
+    this.codeBtn.setAttribute(
+      "aria-label",
+      on ? "Read code blocks: on" : "Read code blocks: off",
+    );
+  }
+
+  /**
+   * Enable the download button only when there is freshly generated audio for
+   * the active note that has not already been saved as an MP3.
+   */
+  private updateDownloadButton(): void {
+    if (!this.downloadBtn) {
+      return;
+    }
+    let enabled = false;
+    const active = this.app.workspace.getActiveFile();
+    if (active) {
+      const cached = this.provider().getLastGeneratedAudio(active.path);
+      const dir = active.parent?.path ?? "";
+      const mp3Path = normalizePath(
+        dir ? `${dir}/${active.basename}.mp3` : `${active.basename}.mp3`,
+      );
+      const alreadySaved =
+        this.app.vault.getAbstractFileByPath(mp3Path) instanceof TFile;
+      enabled = cached !== null && !alreadySaved;
+    }
+    this.downloadBtn.disabled = !enabled;
+    this.downloadBtn.toggleClass("is-disabled", !enabled);
   }
 
   private changeSpeed(delta: number): void {
@@ -277,6 +427,7 @@ export class VoicePlayerView extends ItemView {
         : `${this.chapters.length} chapters`,
     );
     this.renderChapters(this.chapters);
+    this.updateDownloadButton();
   }
 
   private renderChapters(chapters: ChapterFile[]): void {
@@ -437,6 +588,23 @@ export class VoicePlayerView extends ItemView {
 
     setIcon(this.playPauseBtn, provider.isPlaying() ? "pause" : "play");
     this.speedEl.setText(`${provider.getSpeed().toFixed(1)}×`);
+
+    // Loading feedback while a note is being synthesized: show the bottom bar
+    // and animate (and disable) the "Read this note" button.
+    const loading = provider.isOperationInProgress();
+    this.loadingBarEl.toggleClass("is-visible", loading);
+    this.readBtn.toggleClass("is-loading", loading);
+    this.readBtn.disabled = loading;
+    this.readBtn.setText(loading ? "Reading…" : "Read this note");
+
+    // Keep the selectors/toggle in sync if settings changed elsewhere.
+    if (this.providerSelect.value !== this.plugin.settings.TTS_PROVIDER) {
+      this.refreshControls();
+    } else {
+      this.voiceSelect.value = provider.getVoice();
+      this.updateCodeButton();
+    }
+    this.updateDownloadButton();
 
     // Detect track end here (rather than via an "ended" listener) so it keeps
     // working across provider swaps, which replace the audio element.

--- a/styles.css
+++ b/styles.css
@@ -640,6 +640,13 @@
   color: var(--text-normal);
 }
 
+.voice-player-download:disabled,
+.voice-player-download.is-disabled {
+  opacity: 0.3;
+  cursor: default;
+  pointer-events: none;
+}
+
 .voice-player-repeat {
   display: flex;
   align-items: center;
@@ -744,4 +751,87 @@
 .voice-player-chapter.is-current .voice-player-chapter-name {
   color: var(--text-accent);
   font-weight: 600;
+}
+
+/* Provider / voice selectors + read-code-blocks toggle */
+.voice-player-options {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.voice-player-select {
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.voice-player-code {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: var(--radius-s);
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.voice-player-code:hover {
+  color: var(--text-normal);
+}
+
+.voice-player-code.is-active {
+  color: var(--interactive-accent);
+}
+
+/* "Read this note" loading animation */
+.voice-player-read.is-loading {
+  opacity: 0.85;
+  cursor: default;
+  animation: voice-player-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes voice-player-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* Indeterminate loading bar, pinned to the bottom of the panel */
+.voice-player-loading {
+  margin-top: auto;
+  height: 3px;
+  border-radius: 3px;
+  background: var(--background-modifier-border);
+  overflow: hidden;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.voice-player-loading.is-visible {
+  opacity: 1;
+}
+
+.voice-player-loading-fill {
+  width: 40%;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--interactive-accent);
+  animation: voice-player-indeterminate 1.1s ease-in-out infinite;
+}
+
+@keyframes voice-player-indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(350%);
+  }
 }


### PR DESCRIPTION
## Summary

Adds user feedback and quick controls to the Voice player view.

## Changes

- **Loading feedback while synthesizing** — an indeterminate loading bar pinned to the bottom of the panel, plus the "Read this note" button animates (pulses, shows "Reading…", and is disabled) so it's clear processing is ongoing. Driven by the provider's operation state.
- **Smart download button** — disabled when there's no freshly generated audio to save and once the current audio has been saved; it enables as soon as a synthesis produces new audio for the active note, and re-enables after re-synthesizing. (Tracks the saved blob rather than checking whether a same-named MP3 exists on disk, which previously left it stuck disabled when the note shared a name with an existing chapter.)
- **Provider & voice selectors** — switch the TTS provider and pick a voice directly in the player (the voice label already carries the language), wired to the existing provider-swap and voice-persist flows.
- **Read-code-blocks toggle** — an on/off button that flips the setting and rebuilds the speech pipeline.

The selectors and toggle stay in sync if the same settings are changed elsewhere (e.g. the settings tab).

## Verification

- `npm run build` ✓
- `npm run lint:check` ✓
- `npm run format:check` ✓
- `npm test` ✓ (8 suites, 81 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1rnTSTSoJn48aGWsCmmuh)_