### PR TITLE
feat: default player pane, folder picker, and What's New modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The Voice player is the heart of the plugin: an audiobook-style pane that turns 
 
 ![Voice player on desktop](./assets/voice-player.png)
 
+- **Always within reach** — the player is docked in the right sidebar (next to Backlinks and Outline) right after install, so it's there whenever you need it. On mobile it opens as a full-screen pane.
 - **Chapters from your folder** — every MP3 saved next to the current note appears as a numbered chapter. Listen to a whole folder like an audiobook, and the chapter you're hearing is highlighted.
+- **Folder picker** — jump between any folders in your vault that contain audio straight from the player, and the chapter list updates to that folder's MP3s. It follows the note you're viewing by default; turn off **Folder Picker Follows Active Note** in settings to keep your chosen folder while you browse.
 - **Transport controls** — previous / next chapter, rewind, play / pause, and fast-forward, with a draggable progress bar and live time display.
 - **Read this note** — generate speech for the note you're viewing with a single click.
 - **Repeat modes** — cycle through _off → repeat one → repeat all_ to loop a single chapter or play through every chapter in the folder.
@@ -119,18 +121,19 @@ Everything is configured in one place: **Settings → Voice**. Pick a provider, 
 
 ![Voice settings](./assets/settings.png)
 
-| Setting                     | What it does                                                                                                                               |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Speech Provider**         | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, or **Azure Speech**. The credential fields below adapt to your choice. |
-| **Voice**                   | Pick the voice, gender, and language used for playback.                                                                                    |
-| **Tempo**                   | Set your preferred reading speed (0.5× to 1.9×, default 1.0×).                                                                             |
-| **Rewind interval**         | How many seconds the rewind control jumps back (1–60s, default 3s).                                                                        |
-| **Fast-forward interval**   | How many seconds the fast-forward control jumps ahead (1–60s, default 3s).                                                                 |
-| **Spell Out Acronyms**      | Read uppercase words letter by letter (AWS Polly). Off by default.                                                                         |
-| **Read Code Blocks**        | Read fenced code blocks aloud instead of skipping them. Off by default.                                                                    |
-| **Skip Website URLs**       | Remove URLs from spoken output while keeping link labels. Off by default.                                                                  |
-| **Auto-Save Audio to Note** | Automatically save and embed the MP3 after each playback. Off by default.                                                                  |
-| **Test Credentials**        | Validate your provider keys; on success it reports how many voices are available.                                                          |
+| Setting                               | What it does                                                                                                                               |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Speech Provider**                   | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, or **Azure Speech**. The credential fields below adapt to your choice. |
+| **Voice**                             | Pick the voice, gender, and language used for playback.                                                                                    |
+| **Tempo**                             | Set your preferred reading speed (0.5× to 1.9×, default 1.0×).                                                                             |
+| **Rewind interval**                   | How many seconds the rewind control jumps back (1–60s, default 3s).                                                                        |
+| **Fast-forward interval**             | How many seconds the fast-forward control jumps ahead (1–60s, default 3s).                                                                 |
+| **Spell Out Acronyms**                | Read uppercase words letter by letter (AWS Polly). Off by default.                                                                         |
+| **Read Code Blocks**                  | Read fenced code blocks aloud instead of skipping them. Off by default.                                                                    |
+| **Skip Website URLs**                 | Remove URLs from spoken output while keeping link labels. Off by default.                                                                  |
+| **Auto-Save Audio to Note**           | Automatically save and embed the MP3 after each playback. Off by default.                                                                  |
+| **Folder Picker Follows Active Note** | Player's folder picker auto-switches to the folder of the note you're viewing. On by default; turn off to keep your chosen folder.         |
+| **Test Credentials**                  | Validate your provider keys; on success it reports how many voices are available.                                                          |
 
 ## Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Everything is configured in one place: **Settings → Voice**. Pick a provider, 
 
 ## Keyboard Shortcuts
 
-Voice ships **15 commands** you can bind to any hotkey. No keys are assigned by default — open **Settings → Hotkeys**, search for **Voice**, and assign whatever feels natural. (In the command palette, each command is prefixed with **Voice:**.)
+Voice ships **16 commands** you can bind to any hotkey. No keys are assigned by default — open **Settings → Hotkeys**, search for **Voice**, and assign whatever feels natural. (In the command palette, each command is prefixed with **Voice:**.)
 
 | Command                                                                   | What it does                             |
 | ------------------------------------------------------------------------- | ---------------------------------------- |
@@ -156,6 +156,7 @@ Voice ships **15 commands** you can bind to any hotkey. No keys are assigned by 
 | Save the current audio as an MP3 and embed it in the note.                | Download and embed the audio             |
 | Switch to the next speaker.                                               | Cycle to the next voice                  |
 | Open the player.                                                          | Open the Voice player pane               |
+| Show what's new.                                                          | Reopen the latest "What's New" note      |
 
 ## Choose Your Speech Provider
 

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -279,6 +279,20 @@ export class VoiceSettingTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(containerEl)
+      .setName("Folder Picker Follows Active Note")
+      .setDesc(
+        "When enabled, the player's folder picker automatically switches to the folder of the note you are viewing. Disable it to keep the folder you selected in the player when you switch notes. Enabled by default.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.folderSelectorFollowsNote)
+          .onChange(async (value) => {
+            this.plugin.settings.folderSelectorFollowsNote = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
     // Provider-specific credentials
     if (this.plugin.settings.TTS_PROVIDER === "elevenlabs") {
       this.displayElevenLabsSettings(containerEl);

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -37,8 +37,14 @@ export interface VoiceSettings {
   // Playback: how many seconds the rewind/fast-forward controls jump
   rewindSeconds: number;
   forwardSeconds: number;
+  // Player: when true, the player's folder picker follows the active note's
+  // folder; when false the chosen folder stays put across note switches.
+  folderSelectorFollowsNote: boolean;
   // Internal: tracks the one-time reset of the legacy spellOutAcronyms default
   acronymDefaultMigrated: boolean;
+  // Internal: tracks the one-time placement of the player in the right sidebar
+  // so it is discoverable by default without re-adding it after the user closes it.
+  playerPanePlaced: boolean;
 }
 
 /**
@@ -287,5 +293,7 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   skipUrls: false,
   rewindSeconds: DEFAULT_SKIP_SECONDS,
   forwardSeconds: DEFAULT_SKIP_SECONDS,
+  folderSelectorFollowsNote: true,
   acronymDefaultMigrated: false,
+  playerPanePlaced: false,
 };

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -45,6 +45,9 @@ export interface VoiceSettings {
   // Internal: tracks the one-time placement of the player in the right sidebar
   // so it is discoverable by default without re-adding it after the user closes it.
   playerPanePlaced: boolean;
+  // Internal: the plugin version whose "What's New" note the user has already
+  // seen, so it is shown only once per install/update.
+  lastWhatsNewVersion: string;
 }
 
 /**
@@ -296,4 +299,5 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   folderSelectorFollowsNote: true,
   acronymDefaultMigrated: false,
   playerPanePlaced: false,
+  lastWhatsNewVersion: "",
 };

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -1,7 +1,13 @@
 import { ItemView, WorkspaceLeaf, TFile, setIcon } from "obsidian";
 import type { Voice } from "../utils/VoicePlugin";
 import type { TtsProvider } from "../settings/VoiceSettings";
-import { listChapters, type ChapterFile } from "../utils/chapters";
+import {
+  listChapters,
+  listMp3Folders,
+  normalizeFolderPath,
+  type ChapterFile,
+  type Mp3Folder,
+} from "../utils/chapters";
 
 export const VIEW_TYPE_VOICE_PLAYER = "voice-player-view";
 
@@ -25,7 +31,8 @@ const PROVIDERS: { id: TtsProvider; label: string }[] = [
  * full-screen pane. It binds to the active speech provider's audio element
  * (polling, so provider swaps and chapter playback are handled uniformly) and
  * offers transport controls, a scrubber, speed, and a "chapters" list built
- * from the MP3 files in the active note's folder.
+ * from the MP3 files in the selected folder. A folder picker lists every vault
+ * folder that contains MP3s so the player can browse audio across the vault.
  */
 export class VoicePlayerView extends ItemView {
   private plugin: Voice;
@@ -45,12 +52,17 @@ export class VoicePlayerView extends ItemView {
   private downloadBtn: HTMLButtonElement;
   private providerSelect: HTMLSelectElement;
   private voiceSelect: HTMLSelectElement;
+  private folderSelect: HTMLSelectElement;
   private codeBtn: HTMLElement;
   private loadingBarEl: HTMLElement;
 
   private isScrubbing = false;
   private currentChapterPath: string | null = null;
   private chapters: ChapterFile[] = [];
+  // Folders in the vault that contain at least one MP3, and the one currently
+  // selected in the folder picker (drives the chapter list).
+  private folders: Mp3Folder[] = [];
+  private selectedFolderPath: string | null = null;
   private repeatMode: RepeatMode = "none";
   private endedHandled = false;
   // The generated-audio blob that has already been saved via the download
@@ -255,6 +267,17 @@ export class VoicePlayerView extends ItemView {
     setIcon(this.codeBtn, "code");
     this.registerDomEvent(this.codeBtn, "click", () => this.toggleCodeBlocks());
 
+    // Folder picker: choose any vault folder that contains MP3s and list its
+    // tracks as chapters, so the player can browse audio across the vault.
+    const folderRow = root.createDiv({ cls: "voice-player-folder" });
+    this.folderSelect = folderRow.createEl("select", {
+      cls: "voice-player-select voice-player-folder-select dropdown",
+      attr: { "aria-label": "Audio folder" },
+    });
+    this.registerDomEvent(this.folderSelect, "change", () =>
+      this.changeFolder(this.folderSelect.value),
+    );
+
     // Chapters
     const chapters = root.createDiv({ cls: "voice-player-chapters" });
     chapters
@@ -410,7 +433,11 @@ export class VoicePlayerView extends ItemView {
     }
   }
 
-  /** Refresh the title and the chapter list from the active note. */
+  /**
+   * Refresh the title, the folder picker, and the chapter list. The folder
+   * picker lists every vault folder that holds MP3s; the selected folder drives
+   * the chapter list.
+   */
   private refreshContext(): void {
     if (!this.titleEl) {
       return;
@@ -418,10 +445,91 @@ export class VoicePlayerView extends ItemView {
     const active = this.app.workspace.getActiveFile();
     this.titleEl.setText(active ? active.basename : "Voice player");
 
+    // Collect every folder in the vault that holds at least one MP3.
+    const mp3Files = this.app.vault
+      .getFiles()
+      .filter((f) => f.extension === "mp3");
+    this.folders = listMp3Folders(mp3Files.map((f) => f.path));
+
+    this.selectedFolderPath = this.resolveSelectedFolder(active);
+    this.renderFolderOptions();
+    this.renderSelectedFolderChapters();
+  }
+
+  /**
+   * Decide which folder the chapter list should show. When "follow note" is on
+   * (and the active note's folder has audio) we track the note; otherwise we
+   * keep the user's manual choice, falling back to the active note's folder or
+   * the first available folder when the previous selection no longer exists.
+   */
+  private resolveSelectedFolder(active: TFile | null): string | null {
+    if (this.folders.length === 0) {
+      return null;
+    }
+    const activeFolder =
+      active?.parent != null ? normalizeFolderPath(active.parent.path) : null;
+    const hasFolder = (path: string | null): boolean =>
+      path !== null && this.folders.some((f) => f.path === path);
+
+    if (
+      this.plugin.settings.folderSelectorFollowsNote &&
+      hasFolder(activeFolder)
+    ) {
+      return activeFolder;
+    }
+    if (hasFolder(this.selectedFolderPath)) {
+      return this.selectedFolderPath;
+    }
+    return hasFolder(activeFolder) ? activeFolder : this.folders[0].path;
+  }
+
+  /** Rebuild the folder dropdown from the discovered MP3 folders. */
+  private renderFolderOptions(): void {
+    this.folderSelect.empty();
+    if (this.folders.length === 0) {
+      const placeholder = this.folderSelect.createEl("option", {
+        value: "",
+        text: "No audio folders",
+      });
+      placeholder.disabled = true;
+      this.folderSelect.disabled = true;
+      return;
+    }
+    this.folderSelect.disabled = false;
+    this.folders.forEach((folder) => {
+      this.folderSelect.createEl("option", {
+        value: folder.path,
+        text: folder.name,
+      });
+    });
+    if (this.selectedFolderPath !== null) {
+      this.folderSelect.value = this.selectedFolderPath;
+    }
+  }
+
+  /** Switch the folder whose tracks are listed as chapters. */
+  private changeFolder(folderPath: string): void {
+    if (folderPath === this.selectedFolderPath) {
+      return;
+    }
+    this.selectedFolderPath = folderPath;
+    this.renderSelectedFolderChapters();
+  }
+
+  /** Render the chapters (MP3s) that live in the selected folder. */
+  private renderSelectedFolderChapters(): void {
+    const folderPath = this.selectedFolderPath;
     const mp3Paths =
-      active?.parent?.children
-        .filter((f) => f instanceof TFile && f.extension === "mp3")
-        .map((f) => f.path) ?? [];
+      folderPath === null
+        ? []
+        : this.app.vault
+            .getFiles()
+            .filter(
+              (f) =>
+                f.extension === "mp3" &&
+                normalizeFolderPath(f.parent?.path ?? "/") === folderPath,
+            )
+            .map((f) => f.path);
     this.chapters = listChapters(mp3Paths);
 
     this.subtitleEl.setText(

--- a/src/ui/WhatsNewModal.ts
+++ b/src/ui/WhatsNewModal.ts
@@ -1,0 +1,62 @@
+import { App, Modal, MarkdownRenderer, Component, Setting } from "obsidian";
+import { WHATS_NEW, HERO_IMAGE_URL } from "../utils/whatsNew";
+
+/**
+ * Modal that introduces the latest functionality after an install or update.
+ * Renders the curated {@link WHATS_NEW} markdown and offers a button to open
+ * the Voice player straight away, so the feature is immediately discoverable.
+ */
+export class WhatsNewModal extends Modal {
+  private readonly component: Component;
+  private readonly version: string;
+  private readonly onOpenPlayer: () => void;
+
+  constructor(
+    app: App,
+    version: string,
+    component: Component,
+    onOpenPlayer: () => void,
+  ) {
+    super(app);
+    this.version = version;
+    this.component = component;
+    this.onOpenPlayer = onOpenPlayer;
+  }
+
+  onOpen(): void {
+    const { contentEl, titleEl, modalEl } = this;
+    modalEl.addClass("voice-whats-new-modal");
+    titleEl.setText(`What's new in Voice ${this.version}`);
+
+    // Hero banner (mirrors the README). Loaded remotely; hidden gracefully if
+    // it cannot be fetched, e.g. when the user is offline.
+    const hero = contentEl.createEl("img", {
+      cls: "voice-whats-new-hero",
+      attr: { alt: "Obsidian Voice", src: HERO_IMAGE_URL },
+    });
+    hero.addEventListener("error", () => hero.hide());
+
+    const body = contentEl.createDiv({ cls: "voice-whats-new-body" });
+    // MarkdownRenderer.render is the current rendering API; the component ties
+    // the rendered children's lifecycle to the plugin so they are cleaned up.
+    void MarkdownRenderer.render(this.app, WHATS_NEW, body, "", this.component);
+
+    new Setting(contentEl)
+      .addButton((btn) =>
+        btn
+          .setButtonText("Open Voice player")
+          .setCta()
+          .onClick(() => {
+            this.onOpenPlayer();
+            this.close();
+          }),
+      )
+      .addButton((btn) =>
+        btn.setButtonText("Close").onClick(() => this.close()),
+      );
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -8,6 +8,8 @@ import { MarkdownHelper } from "./MarkdownHelper";
 import { IconEventHandler } from "./IconEventHandler";
 import { TextSpeaker } from "./TextSpeaker";
 import { VoicePlayerView, VIEW_TYPE_VOICE_PLAYER } from "../ui/VoicePlayerView";
+import { WhatsNewModal } from "../ui/WhatsNewModal";
+import { shouldShowWhatsNew } from "./whatsNew";
 
 export class Voice extends Plugin {
   settings: VoiceSettings;
@@ -55,12 +57,43 @@ export class Voice extends Plugin {
       name: "Open the player.",
       callback: () => void this.activatePlayerView(),
     });
+    this.addCommand({
+      id: "show-whats-new",
+      name: "Show what's new.",
+      callback: () => this.showWhatsNew(),
+    });
 
-    // Make the player discoverable out of the box: place it as a tab in the
-    // right sidebar once (after the layout is ready), so new users see it
-    // alongside Backlinks/Outline without first running a command. It is only
-    // placed a single time, so closing it afterwards is respected.
-    this.app.workspace.onLayoutReady(() => void this.placeDefaultPlayerPane());
+    // After the layout is ready: make the player discoverable out of the box
+    // (place it as a sidebar tab once) and surface the "What's New" note once
+    // per install/update so users learn about new functionality.
+    this.app.workspace.onLayoutReady(() => {
+      void this.placeDefaultPlayerPane();
+      this.maybeShowWhatsNew();
+    });
+  }
+
+  /** Open the "What's New" modal for the current version. */
+  private showWhatsNew(): void {
+    new WhatsNewModal(
+      this.app,
+      this.manifest.version,
+      this,
+      () => void this.activatePlayerView(),
+    ).open();
+  }
+
+  /**
+   * Show the "What's New" note once after a fresh install or an update, then
+   * remember the version so it is not shown again until the next upgrade.
+   */
+  private maybeShowWhatsNew(): void {
+    const current = this.manifest.version;
+    if (!shouldShowWhatsNew(current, this.settings.lastWhatsNewVersion)) {
+      return;
+    }
+    this.settings.lastWhatsNewVersion = current;
+    void this.saveSettings();
+    this.showWhatsNew();
   }
 
   /**

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -55,6 +55,35 @@ export class Voice extends Plugin {
       name: "Open the player.",
       callback: () => void this.activatePlayerView(),
     });
+
+    // Make the player discoverable out of the box: place it as a tab in the
+    // right sidebar once (after the layout is ready), so new users see it
+    // alongside Backlinks/Outline without first running a command. It is only
+    // placed a single time, so closing it afterwards is respected.
+    this.app.workspace.onLayoutReady(() => void this.placeDefaultPlayerPane());
+  }
+
+  /**
+   * One-time placement of the player in the right sidebar so it shows up by
+   * default (desktop and mobile). The tab is added without revealing it, so it
+   * does not steal focus from the user's current pane.
+   */
+  private async placeDefaultPlayerPane(): Promise<void> {
+    if (this.settings.playerPanePlaced) {
+      return;
+    }
+    this.settings.playerPanePlaced = true;
+    await this.saveSettings();
+
+    const { workspace } = this.app;
+    if (workspace.getLeavesOfType(VIEW_TYPE_VOICE_PLAYER).length > 0) {
+      return;
+    }
+    const right = workspace.getRightLeaf(false);
+    if (!right) {
+      return;
+    }
+    await right.setViewState({ type: VIEW_TYPE_VOICE_PLAYER });
   }
 
   async speakText(speed?: number) {

--- a/src/utils/chapters.ts
+++ b/src/utils/chapters.ts
@@ -13,6 +13,57 @@ export interface ChapterFile {
   name: string;
 }
 
+export interface Mp3Folder {
+  /** Vault-relative folder path ("/" for the vault root). */
+  path: string;
+  /** Display name (the folder's own name, "/" for the vault root). */
+  name: string;
+}
+
+/**
+ * Normalize a folder path so the vault root is consistently "/".
+ * Obsidian reports the root folder's path as "/" but a derived empty string
+ * can also occur, so we collapse both to "/".
+ */
+export function normalizeFolderPath(path: string): string {
+  return path === "" ? "/" : path;
+}
+
+/**
+ * Display name for a folder: its own name without parent folders (e.g.
+ * "Projects/Audiobooks/Part 1" → "Part 1"). The vault root renders as "/".
+ */
+export function folderDisplayName(path: string): string {
+  const normalized = normalizeFolderPath(path);
+  if (normalized === "/") {
+    return "/";
+  }
+  return normalized.split("/").pop() ?? normalized;
+}
+
+/**
+ * Build the list of folders that contain at least one MP3, derived from a flat
+ * list of MP3 paths. Folders are de-duplicated and sorted naturally by their
+ * display name (case-insensitively), so the player's folder picker only ever
+ * offers directories that actually hold audio.
+ */
+export function listMp3Folders(mp3Paths: string[]): Mp3Folder[] {
+  const folderPaths = new Set<string>();
+  for (const path of mp3Paths) {
+    const slash = path.lastIndexOf("/");
+    const folder = slash === -1 ? "/" : path.slice(0, slash);
+    folderPaths.add(normalizeFolderPath(folder));
+  }
+  return [...folderPaths]
+    .map((path) => ({ path, name: folderDisplayName(path) }))
+    .sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      }),
+    );
+}
+
 /**
  * Display name for a chapter: the file name without folders or the .mp3
  * extension (e.g. "notes/Chapter 2.mp3" → "Chapter 2").

--- a/src/utils/whatsNew.ts
+++ b/src/utils/whatsNew.ts
@@ -30,7 +30,7 @@ Voice now has a full **audiobook-style player** — and it lives in the right si
 - **Read this note & download** — generate speech and save an MP3 without leaving the player.
 - **Switch provider & voice** — change between AWS Polly, ElevenLabs, Google Cloud, and Azure Speech directly in the player.
 
-## ✨ Everything new since 1.8.0
+## ✨ Everything you need to know
 
 **Player & playback**
 

--- a/src/utils/whatsNew.ts
+++ b/src/utils/whatsNew.ts
@@ -22,31 +22,21 @@ export const HERO_IMAGE_URL =
  */
 export const WHATS_NEW = `## 🔊 The Voice player is here
 
-Voice now has a full **audiobook-style player** — and it lives in the right
-sidebar (next to Backlinks and Outline) by default, so it is always one click
-away. If you have not updated in a while, this is the big one.
+Voice now has a full **audiobook-style player** — and it lives in the right sidebar (next to Backlinks and Outline) by default, so it is always one click away. If you have not updated in a while, this is the big one.
 
-- **Play your notes like chapters** — every MP3 in a folder shows up as a
-  numbered chapter you can play, skip, and repeat.
-- **Browse audio across your vault** — a folder picker lets you jump between any
-  folders that contain audio, right from the player.
-- **Transport controls** — play / pause, previous / next, rewind, fast-forward,
-  a draggable progress bar, and on-the-fly speed.
-- **Read this note & download** — generate speech and save an MP3 without
-  leaving the player.
-- **Switch provider & voice** — change between AWS Polly, ElevenLabs, Google
-  Cloud, and Azure Speech directly in the player.
+- **Play your notes like chapters** — every MP3 in a folder shows up as a numbered chapter you can play, skip, and repeat.
+- **Browse audio across your vault** — a folder picker lets you jump between any folders that contain audio, right from the player.
+- **Transport controls** — play / pause, previous / next, rewind, fast-forward, a draggable progress bar, and on-the-fly speed.
+- **Read this note & download** — generate speech and save an MP3 without leaving the player.
+- **Switch provider & voice** — change between AWS Polly, ElevenLabs, Google Cloud, and Azure Speech directly in the player.
 
 ## ✨ Everything new since 1.8.0
 
 **Player & playback**
 
-- **Voice player shows by default** in the right sidebar, with a **folder
-  picker** to browse audio across the vault.
-- **In-player controls**: switch provider, voice, and read-code-blocks, with
-  live loading feedback while a note is synthesized.
-- **Collapsible, audiobook-style player** with chapters, transport controls,
-  scrubber, and repeat modes (off / one / all).
+- **Voice player shows by default** in the right sidebar, with a **folder picker** to browse audio across the vault.
+- **In-player controls**: switch provider, voice, and read-code-blocks, with live loading feedback while a note is synthesized.
+- **Collapsible, audiobook-style player** with chapters, transport controls, scrubber, and repeat modes (off / one / all).
 - **Configurable rewind & fast-forward** intervals (1–60 seconds each).
 
 **More engines, more voices**
@@ -57,12 +47,10 @@ away. If you have not updated in a while, this is the big one.
 
 **Your audio files**
 
-- **Separate "Auto-Save" and "Embed" toggles** — download MP3s with or without
-  embedding them into the note.
+- **Separate "Auto-Save" and "Embed" toggles** — download MP3s with or without embedding them into the note.
 - **Skip website URLs** and **read code blocks** content toggles.
 
-Open the player from the **audio-waveform ribbon icon**, the **"Open the
-player."** command, or the button below.`;
+Open the player from the **audio-waveform ribbon icon**, the **"Open the player."** command, or the button below.`;
 
 /**
  * Whether to show the "What's New" note for the running version. We show it

--- a/src/utils/whatsNew.ts
+++ b/src/utils/whatsNew.ts
@@ -1,0 +1,78 @@
+/**
+ * "What's New" changelog shown once after a fresh install or an update.
+ *
+ * Its purpose is discovery: many long-time users have not updated in a while
+ * and do not know the Voice player exists yet, and new users should learn
+ * about it right away. The pure version-comparison logic lives here, separate
+ * from the Obsidian Modal, so it can be unit-tested.
+ */
+
+/**
+ * Hero image shown at the top of the "What's New" modal. It mirrors the README
+ * hero; it is loaded remotely (rather than bundled) because the asset is large,
+ * and the modal hides it gracefully if it cannot be fetched (e.g. offline).
+ */
+export const HERO_IMAGE_URL =
+  "https://raw.githubusercontent.com/chrisurf/obsidian-voice/main/assets/hero.png";
+
+/**
+ * Markdown rendered inside the "What's New" modal. Leads with the Voice player
+ * (the headline feature many users have not discovered yet), then summarizes
+ * everything added since 1.8.0 so long-time users catch up at a glance.
+ */
+export const WHATS_NEW = `## 🔊 The Voice player is here
+
+Voice now has a full **audiobook-style player** — and it lives in the right
+sidebar (next to Backlinks and Outline) by default, so it is always one click
+away. If you have not updated in a while, this is the big one.
+
+- **Play your notes like chapters** — every MP3 in a folder shows up as a
+  numbered chapter you can play, skip, and repeat.
+- **Browse audio across your vault** — a folder picker lets you jump between any
+  folders that contain audio, right from the player.
+- **Transport controls** — play / pause, previous / next, rewind, fast-forward,
+  a draggable progress bar, and on-the-fly speed.
+- **Read this note & download** — generate speech and save an MP3 without
+  leaving the player.
+- **Switch provider & voice** — change between AWS Polly, ElevenLabs, Google
+  Cloud, and Azure Speech directly in the player.
+
+## ✨ Everything new since 1.8.0
+
+**Player & playback**
+
+- **Voice player shows by default** in the right sidebar, with a **folder
+  picker** to browse audio across the vault.
+- **In-player controls**: switch provider, voice, and read-code-blocks, with
+  live loading feedback while a note is synthesized.
+- **Collapsible, audiobook-style player** with chapters, transport controls,
+  scrubber, and repeat modes (off / one / all).
+- **Configurable rewind & fast-forward** intervals (1–60 seconds each).
+
+**More engines, more voices**
+
+- **ElevenLabs** support — premade & multilingual voices.
+- **Google Cloud Text-to-Speech** support, plus extra hotkey commands.
+- **Azure AI Speech** support — neural voices across many languages.
+
+**Your audio files**
+
+- **Separate "Auto-Save" and "Embed" toggles** — download MP3s with or without
+  embedding them into the note.
+- **Skip website URLs** and **read code blocks** content toggles.
+
+Open the player from the **audio-waveform ribbon icon**, the **"Open the
+player."** command, or the button below.`;
+
+/**
+ * Whether to show the "What's New" note for the running version. We show it
+ * whenever the currently installed version differs from the last one the user
+ * has already seen — this covers both a fresh install (no version seen yet)
+ * and an upgrade, while never showing twice for the same version.
+ */
+export function shouldShowWhatsNew(
+  currentVersion: string,
+  lastSeenVersion: string,
+): boolean {
+  return currentVersion !== "" && currentVersion !== lastSeenVersion;
+}

--- a/styles.css
+++ b/styles.css
@@ -799,6 +799,32 @@
   max-width: 100%;
 }
 
+/* "What's New" modal: hero banner + changelog */
+.voice-whats-new-modal {
+  max-width: 640px;
+}
+
+.voice-whats-new-hero {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-m);
+  margin-bottom: 12px;
+}
+
+.voice-whats-new-body {
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.voice-whats-new-body h2 {
+  margin-top: 1em;
+}
+
+.voice-whats-new-body h2:first-child {
+  margin-top: 0;
+}
+
 /* "Read this note" loading animation */
 .voice-player-read.is-loading {
   opacity: 0.85;

--- a/styles.css
+++ b/styles.css
@@ -787,6 +787,18 @@
   color: var(--interactive-accent);
 }
 
+/* Folder picker: choose which folder's MP3s show up as chapters */
+.voice-player-folder {
+  display: flex;
+  align-items: center;
+}
+
+.voice-player-folder-select {
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 100%;
+}
+
 /* "Read this note" loading animation */
 .voice-player-read.is-loading {
   opacity: 0.85;

--- a/tests/chapters.unit.test.ts
+++ b/tests/chapters.unit.test.ts
@@ -1,4 +1,10 @@
-import { listChapters, chapterName } from "../src/utils/chapters";
+import {
+  listChapters,
+  chapterName,
+  listMp3Folders,
+  folderDisplayName,
+  normalizeFolderPath,
+} from "../src/utils/chapters";
 
 describe("Unit Tests - Chapter helpers", () => {
   describe("chapterName", () => {
@@ -42,6 +48,67 @@ describe("Unit Tests - Chapter helpers", () => {
 
     test("handles an empty list", () => {
       expect(listChapters([])).toEqual([]);
+    });
+  });
+
+  describe("normalizeFolderPath", () => {
+    test("maps an empty path to the vault root", () => {
+      expect(normalizeFolderPath("")).toBe("/");
+    });
+
+    test("leaves a non-empty path untouched", () => {
+      expect(normalizeFolderPath("notes/audio")).toBe("notes/audio");
+    });
+  });
+
+  describe("folderDisplayName", () => {
+    test("returns the folder's own name", () => {
+      expect(folderDisplayName("Projects/Audiobooks/Part 1")).toBe("Part 1");
+    });
+
+    test("renders the vault root as a slash", () => {
+      expect(folderDisplayName("/")).toBe("/");
+      expect(folderDisplayName("")).toBe("/");
+    });
+
+    test("handles a single-segment folder", () => {
+      expect(folderDisplayName("audio")).toBe("audio");
+    });
+  });
+
+  describe("listMp3Folders", () => {
+    test("returns only folders that contain MP3s, de-duplicated", () => {
+      const result = listMp3Folders([
+        "notes/audio/a.mp3",
+        "notes/audio/b.mp3",
+        "podcasts/c.mp3",
+      ]);
+      expect(result).toEqual([
+        { path: "notes/audio", name: "audio" },
+        { path: "podcasts", name: "podcasts" },
+      ]);
+    });
+
+    test("treats files in the vault root as the '/' folder", () => {
+      const result = listMp3Folders(["intro.mp3"]);
+      expect(result).toEqual([{ path: "/", name: "/" }]);
+    });
+
+    test("sorts folders naturally by display name", () => {
+      const result = listMp3Folders([
+        "Part 10/a.mp3",
+        "Part 2/b.mp3",
+        "Part 1/c.mp3",
+      ]);
+      expect(result.map((f) => f.name)).toEqual([
+        "Part 1",
+        "Part 2",
+        "Part 10",
+      ]);
+    });
+
+    test("handles an empty list", () => {
+      expect(listMp3Folders([])).toEqual([]);
     });
   });
 });

--- a/tests/whats-new.unit.test.ts
+++ b/tests/whats-new.unit.test.ts
@@ -1,0 +1,33 @@
+import { shouldShowWhatsNew, WHATS_NEW } from "../src/utils/whatsNew";
+
+describe("Unit Tests - What's New", () => {
+  describe("shouldShowWhatsNew", () => {
+    test("shows on a fresh install (no version seen yet)", () => {
+      expect(shouldShowWhatsNew("1.13.0", "")).toBe(true);
+    });
+
+    test("shows after an update to a different version", () => {
+      expect(shouldShowWhatsNew("1.14.0", "1.13.0")).toBe(true);
+    });
+
+    test("does not show again for the same version", () => {
+      expect(shouldShowWhatsNew("1.13.0", "1.13.0")).toBe(false);
+    });
+
+    test("does not show when the current version is unknown", () => {
+      expect(shouldShowWhatsNew("", "")).toBe(false);
+    });
+  });
+
+  describe("WHATS_NEW content", () => {
+    test("highlights the Voice player", () => {
+      expect(WHATS_NEW).toMatch(/Voice player/i);
+    });
+
+    test("mentions the engines added since 1.8.0", () => {
+      expect(WHATS_NEW).toMatch(/ElevenLabs/);
+      expect(WHATS_NEW).toMatch(/Google Cloud/);
+      expect(WHATS_NEW).toMatch(/Azure/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three improvements that make the Voice player discoverable and easier to navigate, plus a one-time "What's New" note so users (especially long-time ones) learn about functionality they may not know exists.

### 1. Player shows by default
The player is now placed as a tab in the right sidebar once after install/update (via `onLayoutReady`), so it appears next to Backlinks/Outline without first running a command — on desktop and mobile. Placement happens a single time (tracked by `playerPanePlaced`), so closing it afterwards is respected.

### 2. Folder picker in the player
A new dropdown between the provider/voice options and the chapter list offers every vault folder that contains MP3s (labelled by folder name). Selecting a folder lists that folder's tracks as chapters, so you can browse audio across the vault from the player. A new setting **Folder Picker Follows Active Note** (on by default) controls whether the picker tracks the active note's folder or keeps a manual choice across note switches.

### 3. "What's New" modal on install/update
Shown once after a fresh install or an update (compares `manifest.version` against a stored `lastWhatsNewVersion`). It leads with the Voice player and summarizes everything added since 1.8.0 (ElevenLabs, Google Cloud, and Azure providers; configurable skip intervals; in-player controls; separate save/embed toggles; the player itself). Includes a README-style hero image (loaded remotely, hidden gracefully when offline), an **Open Voice player** button, and a **Show what's new.** command to reopen on demand.

## Implementation notes
- Pure, unit-tested helpers: `listMp3Folders` / `folderDisplayName` / `normalizeFolderPath` (folder picker) and `shouldShowWhatsNew` (changelog gating).
- New settings: `folderSelectorFollowsNote`, `playerPanePlaced`, `lastWhatsNewVersion`.
- README and `styles.css` updated; new command count reflected.

## Testing
- `npm run build` (typecheck + bundle): clean
- `eslint` + `prettier`: clean
- `jest`: **96/96 passing** (15 new tests across folder + what's-new helpers)

> Note: verified via tests/typecheck/build only — not yet exercised in a live Obsidian instance (no GUI in this environment). The sidebar/modal/hero rendering should be confirmed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVD1tWSWBTUwLcaPNTvdg8)_