### PR TITLE
feat: add OpenAI text-to-speech provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Obsidian Voice — listen to your notes in natural, lifelike speech with AWS Polly, ElevenLabs, Google Cloud, or Azure Speech](./assets/hero.png)
 
-Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian Voice Plugin reads your notes aloud in natural, lifelike speech — powered by your choice of **AWS Polly**, **ElevenLabs**, **Google Cloud**, or **Azure Speech**. Listen with a dedicated player, jump between notes like chapters, change the speed on the fly, and save audio offline — with your credentials kept private in your own account.
+Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian Voice Plugin reads your notes aloud in natural, lifelike speech — powered by your choice of **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI**. Listen with a dedicated player, jump between notes like chapters, change the speed on the fly, and save audio offline — with your credentials kept private in your own account.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 ## Highlights
 
 - **A real audiobook player** — open the Voice player, see your notes as chapters, and play, skip, and repeat just like a podcast app.
-- **Four engines, one experience** — switch between **AWS Polly**, **ElevenLabs**, **Google Cloud**, and **Azure Speech** anytime. Every feature works the same on all of them.
+- **Five engines, one experience** — switch between **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, and **OpenAI** anytime. Every feature works the same on all of them.
 - **Listen in seconds** — turn any note into lifelike speech straight from the ribbon, a command, or the player.
 - **Designed for every device** — the same experience on desktop, iOS, and Android, with a touch-friendly mobile player and control bar.
 - **Own your audio** — download MP3 files, auto-embed them into your note, and keep an offline archive.
@@ -121,19 +121,19 @@ Everything is configured in one place: **Settings → Voice**. Pick a provider, 
 
 ![Voice settings](./assets/settings.png)
 
-| Setting                               | What it does                                                                                                                               |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Speech Provider**                   | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, or **Azure Speech**. The credential fields below adapt to your choice. |
-| **Voice**                             | Pick the voice, gender, and language used for playback.                                                                                    |
-| **Tempo**                             | Set your preferred reading speed (0.5× to 1.9×, default 1.0×).                                                                             |
-| **Rewind interval**                   | How many seconds the rewind control jumps back (1–60s, default 3s).                                                                        |
-| **Fast-forward interval**             | How many seconds the fast-forward control jumps ahead (1–60s, default 3s).                                                                 |
-| **Spell Out Acronyms**                | Read uppercase words letter by letter (AWS Polly). Off by default.                                                                         |
-| **Read Code Blocks**                  | Read fenced code blocks aloud instead of skipping them. Off by default.                                                                    |
-| **Skip Website URLs**                 | Remove URLs from spoken output while keeping link labels. Off by default.                                                                  |
-| **Auto-Save Audio to Note**           | Automatically save and embed the MP3 after each playback. Off by default.                                                                  |
-| **Folder Picker Follows Active Note** | Player's folder picker auto-switches to the folder of the note you're viewing. On by default; turn off to keep your chosen folder.         |
-| **Test Credentials**                  | Validate your provider keys; on success it reports how many voices are available.                                                          |
+| Setting                               | What it does                                                                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Speech Provider**                   | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI**. The credential fields below adapt to your choice. |
+| **Voice**                             | Pick the voice, gender, and language used for playback.                                                                                                |
+| **Tempo**                             | Set your preferred reading speed (0.5× to 1.9×, default 1.0×).                                                                                         |
+| **Rewind interval**                   | How many seconds the rewind control jumps back (1–60s, default 3s).                                                                                    |
+| **Fast-forward interval**             | How many seconds the fast-forward control jumps ahead (1–60s, default 3s).                                                                             |
+| **Spell Out Acronyms**                | Read uppercase words letter by letter (AWS Polly). Off by default.                                                                                     |
+| **Read Code Blocks**                  | Read fenced code blocks aloud instead of skipping them. Off by default.                                                                                |
+| **Skip Website URLs**                 | Remove URLs from spoken output while keeping link labels. Off by default.                                                                              |
+| **Auto-Save Audio to Note**           | Automatically save and embed the MP3 after each playback. Off by default.                                                                              |
+| **Folder Picker Follows Active Note** | Player's folder picker auto-switches to the folder of the note you're viewing. On by default; turn off to keep your chosen folder.                     |
+| **Test Credentials**                  | Validate your provider keys; on success it reports how many voices are available.                                                                      |
 
 ## Keyboard Shortcuts
 
@@ -160,14 +160,14 @@ Voice ships **16 commands** you can bind to any hotkey. No keys are assigned by 
 
 ## Choose Your Speech Provider
 
-Pick **AWS Polly**, **ElevenLabs**, **Google Cloud**, or **Azure Speech** from the **Speech Provider** dropdown in settings. Each provider keeps its own credentials and voice list; everything else — tempo, rewind/fast-forward intervals, downloads, auto-save, and the content toggles — works identically. After entering your credentials, press **Test Credentials** to confirm everything is connected.
+Pick **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI** from the **Speech Provider** dropdown in settings. Each provider keeps its own credentials and voice list; everything else — tempo, rewind/fast-forward intervals, downloads, auto-save, and the content toggles — works identically. After entering your credentials, press **Test Credentials** to confirm everything is connected.
 
-|                 | **AWS Polly**                       | **ElevenLabs**                                      | **Google Cloud**                                  | **Azure Speech**                    |
-| --------------- | ----------------------------------- | --------------------------------------------------- | ------------------------------------------------- | ----------------------------------- |
-| **Voices**      | Neural voices across many languages | Premade & multilingual voices speaking 29 languages | Neural2 & WaveNet voices across many languages    | Neural voices across many languages |
-| **Credentials** | AWS region + Access Key ID & Secret | ElevenLabs API key                                  | Google Cloud API key (Text-to-Speech API enabled) | Azure Speech key + region           |
-| **Emphasis**    | Native SSML pauses & emphasis       | Expressive models with natural `<break>` pauses     | Native SSML pauses & emphasis                     | Native SSML pauses & emphasis       |
-| **Models**      | Neural engine                       | Multilingual v2 / Flash v2.5 / Turbo v2.5           | Neural2 / WaveNet                                 | Neural                              |
+|                 | **AWS Polly**                       | **ElevenLabs**                                      | **Google Cloud**                                  | **Azure Speech**                    | **OpenAI**                                    |
+| --------------- | ----------------------------------- | --------------------------------------------------- | ------------------------------------------------- | ----------------------------------- | --------------------------------------------- |
+| **Voices**      | Neural voices across many languages | Premade & multilingual voices speaking 29 languages | Neural2 & WaveNet voices across many languages    | Neural voices across many languages | Built-in multilingual voices (Alloy, Nova, …) |
+| **Credentials** | AWS region + Access Key ID & Secret | ElevenLabs API key                                  | Google Cloud API key (Text-to-Speech API enabled) | Azure Speech key + region           | OpenAI API key                                |
+| **Emphasis**    | Native SSML pauses & emphasis       | Expressive models with natural `<break>` pauses     | Native SSML pauses & emphasis                     | Native SSML pauses & emphasis       | Natural prosody (no SSML)                     |
+| **Models**      | Neural engine                       | Multilingual v2 / Flash v2.5 / Turbo v2.5           | Neural2 / WaveNet                                 | Neural                              | GPT-4o mini TTS / TTS-1 / TTS-1 HD            |
 
 ## Getting Started
 
@@ -188,6 +188,8 @@ Choose one provider to start — you can switch anytime.
 **Google Cloud** — In the [Google Cloud console](https://console.cloud.google.com/), enable the **Cloud Text-to-Speech API** and create an **API key**. In **Settings → Voice**, choose **Google Cloud**, pick a voice, paste the key, and press **Test Credentials**. (Don't add an HTTP-referrer restriction — see the [provider notes](./TROUBLESHOOTING.md#provider-specific-notes).)
 
 **Azure Speech** — In the [Azure portal](https://portal.azure.com/), create a **Speech** resource and copy a **Key** and **Region**. In **Settings → Voice**, choose **Azure Speech**, select the matching region, pick a voice, paste the key, and press **Test Credentials**.
+
+**OpenAI** — Create an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys). In **Settings → Voice**, choose **OpenAI**, pick a model and voice, paste the key, and press **Test Credentials**.
 
 ## Troubleshooting & Help
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Voice",
   "version": "1.14.0",
   "minAppVersion": "1.5.0",
-  "description": "Listen to your notes and hear them talk Text-to-speech (TTS) for an audiobook experience.",
+  "description": "Listen to your notes as natural speech with text-to-speech (TTS). Read notes aloud, play them like an audiobook in the voice player, download MP3 audio and listen offline hands-free on mobile.",
   "author": "Chris Oguntolu",
   "authorUrl": "https://github.com/chrisurf",
   "isDesktopOnly": false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voice",
   "version": "1.14.0",
-  "description": "Add a voice to Obsidian (https://obsidian.md). Text-to-speech adds sound, audio, and speech to your notes, letting them talk in your workspace, mobile-friendly, perfect for learning or reinforcing ideas as you listen hands-free in an audiobook-like experience.",
+  "description": "Obsidian Voice — Text-to-Speech (TTS) plugin that reads your notes aloud in natural, lifelike speech. Turn notes into an audiobook: a podcast-style voice player with chapters, MP3 audio download, offline listening, and speed control. Listen hands-free on desktop, iOS & Android. Powered by AWS Polly, ElevenLabs, OpenAI, Google Cloud Text-to-Speech & Azure Speech — your credentials stay private. Great for learning, accessibility, and reinforcing ideas by listening.",
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",
@@ -17,10 +17,27 @@
     "lint:check": "eslint src --ext .ts"
   },
   "keywords": [
-    "Obsidian",
-    "Voice",
-    "Plugin",
-    "Text-to-Speech"
+    "obsidian",
+    "voice",
+    "text-to-speech",
+    "tts",
+    "speech",
+    "audio",
+    "audiobook",
+    "read-aloud",
+    "narration",
+    "listen",
+    "aws-polly",
+    "elevenlabs",
+    "openai",
+    "openai-tts",
+    "google-cloud-tts",
+    "azure-speech",
+    "neural-voices",
+    "mp3",
+    "accessibility",
+    "hands-free",
+    "mobile"
   ],
   "author": "Chris Oguntolu",
   "license": "MIT",

--- a/src/service/OpenAiSpeechService.ts
+++ b/src/service/OpenAiSpeechService.ts
@@ -1,6 +1,6 @@
 import { requestUrl } from "obsidian";
 import {
-  ELEVENLABS_VOICES,
+  OPENAI_VOICES,
   type VoiceOption,
   type VoiceSettings,
 } from "../settings/VoiceSettings";
@@ -9,24 +9,26 @@ import type { CredentialValidationResult } from "./SpeechProvider";
 import { chunkPlainText } from "./textChunker";
 
 /**
- * ElevenLabs Text-to-Speech integration.
+ * OpenAI Text-to-Speech integration.
  *
- * - Receives plain spoken text from TextSpeaker (ElevenLabs does not support
- *   full SSML, so the text pipeline is used instead of the SSML pipeline).
- * - Chunks long notes to stay within the per-request character limit and
+ * - Receives plain spoken text from TextSpeaker (OpenAI's speech endpoint does
+ *   not support SSML, so the text pipeline is used instead of the SSML pipeline).
+ * - Chunks long notes to stay within the per-request input limit and
  *   concatenates the resulting MP3 blobs.
- * - Uses Obsidian's requestUrl() to bypass browser CORS (same rationale as the
- *   Polly path) and to keep the API key out of fetch/XHR client requests.
- * - Playback/controls/caching are inherited from BaseSpeechService.
+ * - Uses Obsidian's requestUrl() with a Bearer token to bypass browser CORS
+ *   (same rationale as the other HTTP providers) and to keep the key out of
+ *   fetch/XHR client requests.
+ * - Playback/controls/caching are inherited from BaseSpeechService. Speed is
+ *   applied client-side via the audio element, so it is not sent to the API.
  */
 
-const ELEVENLABS_BASE_URL = "https://api.elevenlabs.io";
-const OUTPUT_FORMAT = "mp3_44100_128";
-// Conservative per-request size. multilingual_v2 allows 10k chars; smaller
-// chunks lower first-audio latency and avoid hitting limits on any model.
-const MAX_CHUNK_CHARS = 3000;
+const OPENAI_BASE_URL = "https://api.openai.com/v1";
+// Conservative per-request size. The speech endpoint accepts up to ~4096
+// characters; smaller chunks lower first-audio latency and stay safely under
+// the limit for every model.
+const MAX_CHUNK_CHARS = 2000;
 
-export class ElevenLabsService extends BaseSpeechService {
+export class OpenAiSpeechService extends BaseSpeechService {
   readonly inputFormat = "text" as const;
 
   private apiKey: string;
@@ -35,20 +37,20 @@ export class ElevenLabsService extends BaseSpeechService {
   constructor(apiKey: string, voice: string, model: string, speed?: number) {
     super(voice, speed);
     this.apiKey = apiKey;
-    this.model = model || "eleven_multilingual_v2";
+    this.model = model || "gpt-4o-mini-tts";
   }
 
   getVoiceOptions(): VoiceOption[] {
-    return ELEVENLABS_VOICES;
+    return OPENAI_VOICES;
   }
 
   updateCredentials(settings: VoiceSettings): void {
-    this.apiKey = settings.ELEVENLABS_API_KEY;
-    this.model = settings.ELEVENLABS_MODEL || "eleven_multilingual_v2";
+    this.apiKey = settings.OPENAI_API_KEY;
+    this.model = settings.OPENAI_MODEL || "gpt-4o-mini-tts";
   }
 
   /**
-   * Synthesize and play plain text via ElevenLabs.
+   * Synthesize and play plain text via OpenAI.
    */
   async speak(
     content: string,
@@ -56,11 +58,11 @@ export class ElevenLabsService extends BaseSpeechService {
     filePath?: string,
   ): Promise<void> {
     if (this.isLoading) {
-      throw new Error("ElevenLabs call already in progress.");
+      throw new Error("OpenAI call already in progress.");
     }
 
     if (!this.apiKey) {
-      const error = new Error("Missing ElevenLabs API key");
+      const error = new Error("Missing OpenAI API key");
       this.reportError(error);
       throw error;
     }
@@ -100,7 +102,7 @@ export class ElevenLabsService extends BaseSpeechService {
       if (error instanceof Error && error.name === "AbortError") {
         return;
       }
-      console.error("Error in ElevenLabs speak:", error);
+      console.error("Error in OpenAI speak:", error);
       this.reportError(error);
       throw error;
     } finally {
@@ -113,76 +115,76 @@ export class ElevenLabsService extends BaseSpeechService {
    * Synthesize a single text chunk and return the MP3 blob.
    */
   private async synthesizeChunk(text: string): Promise<Blob> {
-    const voiceId = this.voice;
-    const url = `${ELEVENLABS_BASE_URL}/v1/text-to-speech/${encodeURIComponent(
-      voiceId,
-    )}?output_format=${OUTPUT_FORMAT}`;
-
     const response = await requestUrl({
-      url,
+      url: `${OPENAI_BASE_URL}/audio/speech`,
       method: "POST",
       headers: {
-        "xi-api-key": this.apiKey,
+        Authorization: `Bearer ${this.apiKey}`,
         "Content-Type": "application/json",
         Accept: "audio/mpeg",
       },
       body: JSON.stringify({
-        text,
-        model_id: this.model,
+        model: this.model,
+        input: text,
+        voice: this.voice,
+        response_format: "mp3",
       }),
       throw: false,
     });
 
     if (response.status === 401) {
-      throw new Error("ElevenLabs: invalid or expired API key (401)");
+      throw new Error("OpenAI: invalid or expired API key (401)");
     }
     if (response.status === 429) {
-      throw new Error("ElevenLabs: rate or concurrency limit reached (429)");
+      throw new Error("OpenAI: rate limit or quota reached (429)");
     }
     if (response.status >= 400) {
-      throw new Error(`ElevenLabs API error (HTTP ${response.status})`);
+      const message = response.json?.error?.message;
+      throw new Error(
+        `OpenAI API error (HTTP ${response.status})${
+          message ? `: ${message}` : ""
+        }`,
+      );
     }
 
     const arrayBuffer = response.arrayBuffer;
     if (!arrayBuffer || arrayBuffer.byteLength === 0) {
-      throw new Error("ElevenLabs returned an empty audio response");
+      throw new Error("OpenAI returned an empty audio response");
     }
 
     return new Blob([arrayBuffer], { type: "audio/mpeg" });
   }
 
   /**
-   * Validate the API key by listing the account's voices.
+   * Validate the API key. OpenAI has no list-voices endpoint, so we probe the
+   * models endpoint; a 200 means the key works. The voice count reflects the
+   * built-in catalog.
    */
   async validateCredentials(): Promise<CredentialValidationResult> {
     if (!this.apiKey) {
-      return { isValid: false, error: "Please enter your ElevenLabs API key." };
+      return { isValid: false, error: "Please enter your OpenAI API key." };
     }
 
     try {
       const response = await requestUrl({
-        url: `${ELEVENLABS_BASE_URL}/v1/voices`,
+        url: `${OPENAI_BASE_URL}/models`,
         method: "GET",
-        headers: { "xi-api-key": this.apiKey },
+        headers: { Authorization: `Bearer ${this.apiKey}` },
         throw: false,
       });
 
       if (response.status === 200) {
-        const voices = response.json?.voices ?? [];
-        return { isValid: true, voiceCount: voices.length };
+        return { isValid: true, voiceCount: OPENAI_VOICES.length };
       }
       if (response.status === 401) {
-        return {
-          isValid: false,
-          error: "Invalid or expired ElevenLabs API key.",
-        };
+        return { isValid: false, error: "Invalid or expired OpenAI API key." };
       }
       return {
         isValid: false,
         error: `Validation failed (HTTP ${response.status}).`,
       };
     } catch (error) {
-      console.error("ElevenLabs credential validation error:", error);
+      console.error("OpenAI credential validation error:", error);
       return {
         isValid: false,
         error: "Network error during validation. Please try again.",
@@ -195,22 +197,22 @@ export class ElevenLabsService extends BaseSpeechService {
       const message = String((error as { message: string }).message);
 
       if (message.includes("401")) {
-        return "Invalid ElevenLabs API key.";
+        return "Invalid OpenAI API key.";
       }
       if (message.includes("429")) {
-        return "ElevenLabs rate limit reached. Please wait and try again.";
+        return "OpenAI rate limit or quota reached. Please wait and try again.";
       }
-      if (message.includes("Missing ElevenLabs API key")) {
-        return "Add your ElevenLabs API key in settings.";
+      if (message.includes("Missing OpenAI API key")) {
+        return "Add your OpenAI API key in settings.";
       }
       if (message.includes("empty audio")) {
-        return "ElevenLabs returned no audio. Try a different voice or model.";
+        return "OpenAI returned no audio. Try a different voice or model.";
       }
       if (message.toLowerCase().includes("network")) {
         return "Connection failed. Check your internet.";
       }
-      return `ElevenLabs error: ${message}`;
+      return `OpenAI error: ${message}`;
     }
-    return "ElevenLabs error. Please try again.";
+    return "OpenAI error. Please try again.";
   }
 }

--- a/src/service/SpeechProviderFactory.ts
+++ b/src/service/SpeechProviderFactory.ts
@@ -8,6 +8,7 @@ import { AwsPollyService } from "./AwsPollyService";
 import { ElevenLabsService } from "./ElevenLabsService";
 import { GoogleTtsService } from "./GoogleTtsService";
 import { AzureSpeechService } from "./AzureSpeechService";
+import { OpenAiSpeechService } from "./OpenAiSpeechService";
 
 /**
  * Create the speech provider selected in settings.
@@ -33,6 +34,13 @@ export function createSpeechProvider(settings: VoiceSettings): SpeechProvider {
       settings.AZURE_API_KEY,
       settings.AZURE_REGION,
       settings.AZURE_VOICE,
+      Number(settings.SPEED),
+    );
+  } else if (settings.TTS_PROVIDER === "openai") {
+    provider = new OpenAiSpeechService(
+      settings.OPENAI_API_KEY,
+      settings.OPENAI_VOICE,
+      settings.OPENAI_MODEL,
       Number(settings.SPEED),
     );
   } else {

--- a/src/service/textChunker.ts
+++ b/src/service/textChunker.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared plain-text chunker for text-input TTS providers (ElevenLabs, OpenAI).
+ *
+ * Splits text into chunks under a character limit, preferring paragraph, then
+ * sentence, then word boundaries so the synthesized audio stays natural and no
+ * single request exceeds the provider's per-call input limit.
+ */
+
+/**
+ * Split text into chunks under the given character limit, preferring paragraph
+ * then sentence then word boundaries.
+ */
+export function chunkPlainText(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let current = "";
+
+  const flush = () => {
+    const trimmed = current.trim();
+    if (trimmed) {
+      chunks.push(trimmed);
+    }
+    current = "";
+  };
+
+  const addPiece = (piece: string, separator: string) => {
+    if (!piece) return;
+    if (current && (current + separator + piece).length > maxLen) {
+      flush();
+    }
+    current = current ? current + separator + piece : piece;
+  };
+
+  const paragraphs = text.split(/\n{2,}/);
+  for (const paragraph of paragraphs) {
+    if (paragraph.length <= maxLen) {
+      addPiece(paragraph, "\n\n");
+      continue;
+    }
+
+    // Paragraph too long: split into sentences. Avoid regex lookbehind
+    // (unsupported on iOS < 16.4) by matching sentence runs incl. their
+    // terminator instead.
+    flush();
+    const sentences = paragraph.match(/[^.!?]+[.!?]*\s*/g) ?? [paragraph];
+    for (const sentence of sentences) {
+      if (sentence.length <= maxLen) {
+        addPiece(sentence, " ");
+        continue;
+      }
+
+      // Sentence too long: hard-split by words.
+      flush();
+      const words = sentence.split(/\s+/);
+      for (const word of words) {
+        if (current && (current + " " + word).length > maxLen) {
+          flush();
+        }
+        current = current ? current + " " + word : word;
+      }
+    }
+  }
+
+  flush();
+  return chunks.length ? chunks : [text];
+}

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -3,6 +3,7 @@ import { Voice } from "../utils/VoicePlugin";
 import {
   ELEVENLABS_MODELS,
   AZURE_REGIONS,
+  OPENAI_MODELS,
   MIN_SKIP_SECONDS,
   MAX_SKIP_SECONDS,
 } from "./VoiceSettings";
@@ -87,13 +88,15 @@ export class VoiceSettingTab extends PluginSettingTab {
           .addOption("elevenlabs", "ElevenLabs")
           .addOption("google", "Google Cloud")
           .addOption("azure", "Azure Speech")
+          .addOption("openai", "OpenAI")
           .setValue(this.plugin.settings.TTS_PROVIDER)
           .onChange(async (value) => {
             this.plugin.settings.TTS_PROVIDER = value as
               | "polly"
               | "elevenlabs"
               | "google"
-              | "azure";
+              | "azure"
+              | "openai";
             await this.plugin.saveSettings();
             // Swap the active provider and rewire the UI/orchestration
             this.plugin.reinitializeProvider();
@@ -300,9 +303,56 @@ export class VoiceSettingTab extends PluginSettingTab {
       this.displayGoogleSettings(containerEl);
     } else if (this.plugin.settings.TTS_PROVIDER === "azure") {
       this.displayAzureSettings(containerEl);
+    } else if (this.plugin.settings.TTS_PROVIDER === "openai") {
+      this.displayOpenAISettings(containerEl);
     } else {
       this.displayPollySettings(containerEl);
     }
+  }
+
+  private displayOpenAISettings(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("OpenAI").setHeading();
+
+    new Setting(containerEl)
+      .setName("Model")
+      .setDesc(
+        "The OpenAI text-to-speech model. GPT-4o mini TTS is recommended; TTS-1 favours latency and TTS-1 HD favours quality.",
+      )
+      .addDropdown((dropdown) => {
+        OPENAI_MODELS.forEach((model) => {
+          dropdown.addOption(model.id, model.label);
+        });
+        dropdown
+          .setValue(this.plugin.settings.OPENAI_MODEL)
+          .onChange(async (value) => {
+            this.plugin.settings.OPENAI_MODEL = value;
+            await this.plugin.saveSettings();
+            this.plugin.reinitializeProviderCredentials();
+          });
+      });
+
+    this.addPasswordSetting(
+      containerEl,
+      "OpenAI API Key",
+      "Your OpenAI API key (from the OpenAI dashboard → API keys).",
+      "Enter your OpenAI API key",
+      this.plugin.settings.OPENAI_API_KEY,
+      async (value) => {
+        this.plugin.settings.OPENAI_API_KEY = value;
+        await this.plugin.saveSettings();
+        this.plugin.reinitializeProviderCredentials();
+      },
+    );
+
+    this.renderCredentialValidation(containerEl, {
+      providerName: "OpenAI",
+      isConfigured: () => !!this.plugin.settings.OPENAI_API_KEY,
+      missingMessage: "Please enter your OpenAI API key before testing.",
+      promptMessage:
+        "Enter your OpenAI API key above, then click 'Test Credentials' to validate",
+      helpText: "Need an OpenAI API key? ",
+      helpUrl: "https://platform.openai.com/api-keys",
+    });
   }
 
   private displayAzureSettings(containerEl: HTMLElement): void {

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -1,7 +1,12 @@
 /**
  * Supported text-to-speech providers
  */
-export type TtsProvider = "polly" | "elevenlabs" | "google" | "azure";
+export type TtsProvider =
+  | "polly"
+  | "elevenlabs"
+  | "google"
+  | "azure"
+  | "openai";
 
 export interface VoiceSettings {
   // Active text-to-speech provider
@@ -27,6 +32,11 @@ export interface VoiceSettings {
   AZURE_API_KEY: string;
   AZURE_REGION: string;
   AZURE_VOICE: string;
+
+  // OpenAI Text-to-Speech
+  OPENAI_API_KEY: string;
+  OPENAI_VOICE: string;
+  OPENAI_MODEL: string;
 
   // Content / speech options (shared across providers)
   spellOutAcronyms: boolean;
@@ -267,6 +277,35 @@ export const AZURE_VOICES: VoiceOption[] = [
   },
 ];
 
+/**
+ * OpenAI Text-to-Speech models selectable in the settings.
+ * Default is gpt-4o-mini-tts (newest, expressive, low cost). tts-1 favours
+ * latency and tts-1-hd favours quality; all return MP3 audio.
+ */
+export const OPENAI_MODELS: ModelOption[] = [
+  { id: "gpt-4o-mini-tts", label: "GPT-4o mini TTS (recommended)" },
+  { id: "tts-1", label: "TTS-1 (fast)" },
+  { id: "tts-1-hd", label: "TTS-1 HD (quality)" },
+];
+
+/**
+ * Built-in OpenAI voices. Limited to the set supported across every selectable
+ * model (tts-1, tts-1-hd, and gpt-4o-mini-tts) so switching the model never
+ * invalidates the chosen voice. The voices are multilingual — they speak the
+ * language of the input text — so `lang` is informational only.
+ */
+export const OPENAI_VOICES: VoiceOption[] = [
+  { id: "alloy", label: "Alloy (Neutral)", lang: "en-US" },
+  { id: "ash", label: "Ash (Expressive)", lang: "en-US" },
+  { id: "coral", label: "Coral (Warm)", lang: "en-US" },
+  { id: "echo", label: "Echo (Male)", lang: "en-US" },
+  { id: "fable", label: "Fable (British)", lang: "en-GB" },
+  { id: "onyx", label: "Onyx (Deep)", lang: "en-US" },
+  { id: "nova", label: "Nova (Female)", lang: "en-US" },
+  { id: "sage", label: "Sage (Calm)", lang: "en-US" },
+  { id: "shimmer", label: "Shimmer (Soft)", lang: "en-US" },
+];
+
 export const DEFAULT_SETTINGS: VoiceSettings = {
   TTS_PROVIDER: "polly",
 
@@ -286,6 +325,10 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   AZURE_API_KEY: "",
   AZURE_REGION: "eastus",
   AZURE_VOICE: "en-US-JennyNeural",
+
+  OPENAI_API_KEY: "",
+  OPENAI_VOICE: "alloy",
+  OPENAI_MODEL: "gpt-4o-mini-tts",
 
   spellOutAcronyms: false,
   readCodeBlocks: false,

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -22,6 +22,7 @@ const PROVIDERS: { id: TtsProvider; label: string }[] = [
   { id: "elevenlabs", label: "ElevenLabs" },
   { id: "google", label: "Google Cloud" },
   { id: "azure", label: "Azure Speech" },
+  { id: "openai", label: "OpenAI" },
 ];
 
 /**

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -202,6 +202,8 @@ export class Voice extends Plugin {
       this.settings.GOOGLE_VOICE = voiceId;
     } else if (this.settings.TTS_PROVIDER === "azure") {
       this.settings.AZURE_VOICE = voiceId;
+    } else if (this.settings.TTS_PROVIDER === "openai") {
+      this.settings.OPENAI_VOICE = voiceId;
     } else {
       this.settings.VOICE = voiceId;
     }

--- a/src/utils/whatsNew.ts
+++ b/src/utils/whatsNew.ts
@@ -28,7 +28,7 @@ Voice now has a full **audiobook-style player** — and it lives in the right si
 - **Browse audio across your vault** — a folder picker lets you jump between any folders that contain audio, right from the player.
 - **Transport controls** — play / pause, previous / next, rewind, fast-forward, a draggable progress bar, and on-the-fly speed.
 - **Read this note & download** — generate speech and save an MP3 without leaving the player.
-- **Switch provider & voice** — change between AWS Polly, ElevenLabs, Google Cloud, and Azure Speech directly in the player.
+- **Switch provider & voice** — change between AWS Polly, ElevenLabs, Google Cloud, Azure Speech, and OpenAI directly in the player.
 
 ## ✨ Everything you need to know
 
@@ -44,6 +44,7 @@ Voice now has a full **audiobook-style player** — and it lives in the right si
 - **ElevenLabs** support — premade & multilingual voices.
 - **Google Cloud Text-to-Speech** support, plus extra hotkey commands.
 - **Azure AI Speech** support — neural voices across many languages.
+- **OpenAI** support — built-in voices (Alloy, Nova, …) with GPT-4o mini TTS.
 
 **Your audio files**
 

--- a/tests/openai.unit.test.ts
+++ b/tests/openai.unit.test.ts
@@ -1,0 +1,146 @@
+import { requestUrl } from "obsidian";
+import { OpenAiSpeechService } from "../src/service/OpenAiSpeechService";
+import { createSpeechProvider } from "../src/service/SpeechProviderFactory";
+import { DEFAULT_SETTINGS } from "../src/settings/VoiceSettings";
+
+const mockRequestUrl = requestUrl as jest.Mock;
+
+describe("Unit Tests - OpenAI Provider", () => {
+  beforeEach(() => {
+    mockRequestUrl.mockReset();
+  });
+
+  describe("Provider basics", () => {
+    test("declares the plain-text input format", () => {
+      const service = new OpenAiSpeechService(
+        "key",
+        "alloy",
+        "gpt-4o-mini-tts",
+        1.0,
+      );
+      expect(service.inputFormat).toBe("text");
+    });
+
+    test("exposes a non-empty voice catalog", () => {
+      const service = new OpenAiSpeechService(
+        "key",
+        "alloy",
+        "gpt-4o-mini-tts",
+        1.0,
+      );
+      expect(service.getVoiceOptions().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Credential validation", () => {
+    test("rejects an empty API key without a network call", async () => {
+      const service = new OpenAiSpeechService("", "alloy", "tts-1", 1.0);
+      const result = await service.validateCredentials();
+      expect(result.isValid).toBe(false);
+      expect(mockRequestUrl).not.toHaveBeenCalled();
+    });
+
+    test("probes the models endpoint and reports the built-in voice count", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        json: { data: [{ id: "gpt-4o-mini-tts" }] },
+      });
+      const service = new OpenAiSpeechService("key", "alloy", "tts-1", 1.0);
+      const result = await service.validateCredentials();
+      expect(result.isValid).toBe(true);
+      expect(result.voiceCount).toBe(service.getVoiceOptions().length);
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.url).toContain("/v1/models");
+      expect(call.headers.Authorization).toBe("Bearer key");
+    });
+
+    test("treats HTTP 401 as an invalid key", async () => {
+      mockRequestUrl.mockResolvedValue({ status: 401 });
+      const service = new OpenAiSpeechService("bad", "alloy", "tts-1", 1.0);
+      const result = await service.validateCredentials();
+      expect(result.isValid).toBe(false);
+      expect(result.error).toMatch(/invalid/i);
+    });
+  });
+
+  describe("Synthesis", () => {
+    test("calls the speech endpoint with the right URL, headers and body", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(32),
+      });
+
+      const service = new OpenAiSpeechService(
+        "my-key",
+        "nova",
+        "gpt-4o-mini-tts",
+        1.0,
+      );
+      await service.speak("Hello world.", 1.0, "note.md");
+
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.url).toContain("/v1/audio/speech");
+      expect(call.method).toBe("POST");
+      expect(call.headers.Authorization).toBe("Bearer my-key");
+      const body = JSON.parse(call.body);
+      expect(body.input).toBe("Hello world.");
+      expect(body.voice).toBe("nova");
+      expect(body.model).toBe("gpt-4o-mini-tts");
+      expect(body.response_format).toBe("mp3");
+
+      // Audio should be cached for the active note (download support)
+      expect(service.getLastGeneratedAudio("note.md")).not.toBeNull();
+    });
+
+    test("chunks long text into multiple requests", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(16),
+      });
+
+      // Two paragraphs of ~1500 chars each → exceeds the 2000 char chunk size
+      const paragraph = "word ".repeat(300).trim(); // ~1500 chars
+      const longText = [paragraph, paragraph].join("\n\n");
+
+      const service = new OpenAiSpeechService("key", "alloy", "tts-1", 1.0);
+      await service.speak(longText);
+
+      expect(mockRequestUrl.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    test("throws and reports an error when the API key is missing", async () => {
+      const service = new OpenAiSpeechService("", "alloy", "tts-1", 1.0);
+      const errorCallback = jest.fn();
+      service.setErrorCallback(errorCallback);
+
+      await expect(service.speak("Hello")).rejects.toThrow();
+      expect(errorCallback).toHaveBeenCalled();
+      expect(mockRequestUrl).not.toHaveBeenCalled();
+    });
+
+    test("surfaces a friendly message on HTTP 401 during synthesis", async () => {
+      mockRequestUrl.mockResolvedValue({ status: 401 });
+      const service = new OpenAiSpeechService("bad", "alloy", "tts-1", 1.0);
+      const errorCallback = jest.fn();
+      service.setErrorCallback(errorCallback);
+
+      await expect(service.speak("Hello")).rejects.toThrow();
+      expect(errorCallback).toHaveBeenCalledWith(
+        expect.stringMatching(/invalid/i),
+      );
+    });
+  });
+});
+
+describe("Unit Tests - Speech Provider Factory (OpenAI)", () => {
+  test("creates a text provider for OpenAI", () => {
+    const provider = createSpeechProvider({
+      ...DEFAULT_SETTINGS,
+      TTS_PROVIDER: "openai",
+    });
+    expect(provider.inputFormat).toBe("text");
+    expect(provider.getVoiceOptions().some((v) => v.id === "alloy")).toBe(true);
+  });
+});

--- a/tests/text-chunker.unit.test.ts
+++ b/tests/text-chunker.unit.test.ts
@@ -1,0 +1,37 @@
+import { chunkPlainText } from "../src/service/textChunker";
+
+describe("Unit Tests - Plain text chunker", () => {
+  test("returns the text as a single chunk when under the limit", () => {
+    expect(chunkPlainText("short text", 100)).toEqual(["short text"]);
+  });
+
+  test("splits on paragraph boundaries when possible", () => {
+    const a = "a".repeat(40);
+    const b = "b".repeat(40);
+    const chunks = chunkPlainText(`${a}\n\n${b}`, 50);
+    expect(chunks).toEqual([a, b]);
+  });
+
+  test("keeps every chunk within the limit", () => {
+    const paragraph = "word ".repeat(300).trim(); // ~1500 chars
+    const text = [paragraph, paragraph, paragraph].join("\n\n");
+    const chunks = chunkPlainText(text, 1000);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(1000);
+    }
+  });
+
+  test("hard-splits a single oversized word run", () => {
+    const text = "x".repeat(250);
+    const chunks = chunkPlainText(text, 100);
+    // No whitespace to break on, but it still must not lose content.
+    expect(chunks.join("")).toBe(text);
+  });
+
+  test("does not produce empty chunks", () => {
+    const text = "Sentence one. Sentence two. Sentence three.".repeat(50);
+    const chunks = chunkPlainText(text, 80);
+    expect(chunks.every((c) => c.trim().length > 0)).toBe(true);
+  });
+});

--- a/tests/whats-new.unit.test.ts
+++ b/tests/whats-new.unit.test.ts
@@ -24,10 +24,11 @@ describe("Unit Tests - What's New", () => {
       expect(WHATS_NEW).toMatch(/Voice player/i);
     });
 
-    test("mentions the engines added since 1.8.0", () => {
+    test("mentions the available engines", () => {
       expect(WHATS_NEW).toMatch(/ElevenLabs/);
       expect(WHATS_NEW).toMatch(/Google Cloud/);
       expect(WHATS_NEW).toMatch(/Azure/);
+      expect(WHATS_NEW).toMatch(/OpenAI/);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,7 +24,7 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
-"@aws-crypto/sha256-js@^5.2.0", "@aws-crypto/sha256-js@5.2.0":
+"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz"
   integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
@@ -340,7 +340,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz"
   integrity sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9", "@babel/core@^7.8.0", "@babel/core@>=7.0.0-beta.0 <8":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz"
   integrity sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==
@@ -594,27 +594,135 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@codemirror/state@^6.5.0", "@codemirror/state@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz"
-  integrity sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==
-  dependencies:
-    "@marijn/find-cluster-break" "^1.0.0"
+"@esbuild/aix-ppc64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz#7a01a8d2ec2fbb2dac78adad09b0fa781e4082be"
+  integrity sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==
 
-"@codemirror/view@6.38.6":
-  version "6.38.6"
-  resolved "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz"
-  integrity sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==
-  dependencies:
-    "@codemirror/state" "^6.5.0"
-    crelt "^1.0.6"
-    style-mod "^4.1.0"
-    w3c-keyname "^2.2.4"
+"@esbuild/android-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz#b540a27d14e4afd058496a4dbec4d3f414db110a"
+  integrity sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==
+
+"@esbuild/android-arm@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.1.tgz#704bd297de6d762de54eabbeafbf55f6756abe2f"
+  integrity sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==
+
+"@esbuild/android-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.1.tgz#d1cb166d34b0fbf0fe8ab460a5594f24a378701e"
+  integrity sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==
+
+"@esbuild/darwin-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz#1034b26457fc886368fe61bbd09f653f6afa8e54"
+  integrity sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==
+
+"@esbuild/darwin-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz#65556a432a1e4d72032d8218c1932fcca1a49772"
+  integrity sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==
+
+"@esbuild/freebsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz#2e61e0592f9030d7e3dae18ee25ebc535918aef6"
+  integrity sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==
+
+"@esbuild/freebsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz#c95ec289959ef8079c4dca817a1e2c4be66b9bd3"
+  integrity sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==
+
+"@esbuild/linux-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz#40b22175dda06182f3ee8141186c5ff304c4a717"
+  integrity sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==
+
+"@esbuild/linux-arm@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz#c09a0f67917592ac0de892a9be4d3814debd2a6c"
+  integrity sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==
+
+"@esbuild/linux-ia32@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz#a580f9c676797833891e519fc7a1337c8afd8db3"
+  integrity sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==
+
+"@esbuild/linux-loong64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz#46452cf321dc7f9e91c2fa780a56bb56e79cd68b"
+  integrity sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==
+
+"@esbuild/linux-mips64el@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz#4211b3184dd6608f53dcb22e39f5d34ee08852c8"
+  integrity sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==
+
+"@esbuild/linux-ppc64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz#697857c2a61cb9b0b6bb6652e40c1dc5e1ca8e5d"
+  integrity sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==
+
+"@esbuild/linux-riscv64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz#d192943eb146a40ac4c6497d0cf7be35b986bf08"
+  integrity sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==
+
+"@esbuild/linux-s390x@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz#acea0356da0e0ebc08f97cf7b9c2e401e1e648dc"
+  integrity sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==
 
 "@esbuild/linux-x64@0.28.1":
   version "0.28.1"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz"
   integrity sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==
+
+"@esbuild/netbsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz#8bcd77077a0dce3378b574fedb26d2a253b73d36"
+  integrity sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==
+
+"@esbuild/netbsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz#e7fb2a01e99c830c94e6623cd9fefb4c8fb58347"
+  integrity sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==
+
+"@esbuild/openbsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz#c52909372db8b86e2c55e05a8940033b5660a3b2"
+  integrity sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==
+
+"@esbuild/openbsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz#c427b9be5a64c262ff9a7eb70b5fbbaadf446c6c"
+  integrity sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==
+
+"@esbuild/openharmony-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz#dc9b147baca2e6c4b3c85571741ef4860a489097"
+  integrity sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==
+
+"@esbuild/sunos-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz#ce866d12df13c15e4c99f073a3d466f6e0649b3a"
+  integrity sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==
+
+"@esbuild/win32-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz#7468e3692d01d629d5941e5d83817bb80f9e39b4"
+  integrity sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==
+
+"@esbuild/win32-ia32@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz#a5bc0063fb2bcab6d0ed63f2a1537958bc269ec6"
+  integrity sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==
+
+"@esbuild/win32-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
+  integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
 
 "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.3.0", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.9.0"
@@ -666,7 +774,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@^9.30.1", "@eslint/js@9.39.1":
+"@eslint/js@9.39.1", "@eslint/js@^9.30.1":
   version "9.39.1"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz"
   integrity sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==
@@ -902,7 +1010,7 @@
     jest-haste-map "^29.7.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@^29.7.0":
+"@jest/transform@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz"
   integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
@@ -923,7 +1031,7 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@^29.6.3":
+"@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz"
   integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
@@ -969,11 +1077,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@marijn/find-cluster-break@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz"
-  integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
-
 "@microsoft/eslint-plugin-sdl@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@microsoft/eslint-plugin-sdl/-/eslint-plugin-sdl-1.1.0.tgz"
@@ -996,7 +1099,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1287,7 +1390,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@^8.46.3", "@typescript-eslint/parser@8.46.3":
+"@typescript-eslint/parser@8.46.3":
   version "8.46.3"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.3.tgz"
   integrity sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==
@@ -1315,7 +1418,7 @@
     "@typescript-eslint/types" "8.46.3"
     "@typescript-eslint/visitor-keys" "8.46.3"
 
-"@typescript-eslint/tsconfig-utils@^8.46.3", "@typescript-eslint/tsconfig-utils@8.46.3":
+"@typescript-eslint/tsconfig-utils@8.46.3", "@typescript-eslint/tsconfig-utils@^8.46.3":
   version "8.46.3"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.3.tgz"
   integrity sha512-GLupljMniHNIROP0zE7nCcybptolcH8QZfXOpCfhQDAdwJ/ZTlcaBOYebSOZotpti/3HrHSw7D3PZm75gYFsOA==
@@ -1331,7 +1434,7 @@
     debug "^4.3.4"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/types@^8.33.1", "@typescript-eslint/types@^8.46.3", "@typescript-eslint/types@8.46.3":
+"@typescript-eslint/types@8.46.3", "@typescript-eslint/types@^8.33.1", "@typescript-eslint/types@^8.46.3":
   version "8.46.3"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.3.tgz"
   integrity sha512-G7Ok9WN/ggW7e/tOf8TQYMaxgID3Iujn231hfi0Pc7ZheztIJVpO44ekY00b7akqc6nZcvregk0Jpah3kep6hA==
@@ -1352,7 +1455,7 @@
     semver "^7.6.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/utils@^8.33.1", "@typescript-eslint/utils@8.46.3":
+"@typescript-eslint/utils@8.46.3", "@typescript-eslint/utils@^8.33.1":
   version "8.46.3"
   resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.3.tgz"
   integrity sha512-VXw7qmdkucEx9WkmR3ld/u6VhRyKeiF1uxWwCy/iuNfokjJ7VhsgLSOTjsol8BunSw190zABzpwdNsze2Kpo4g==
@@ -1375,7 +1478,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0, acorn@^8.5.0, acorn@^8.9.0:
+acorn@^8.15.0, acorn@^8.5.0, acorn@^8.9.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -1552,7 +1655,7 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-"babel-jest@^29.0.0 || ^30.0.0", babel-jest@^29.7.0:
+babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz"
   integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==
@@ -1643,14 +1746,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
-  dependencies:
-    balanced-match "^1.0.0"
-
-brace-expansion@^2.0.2:
+brace-expansion@^2.0.1, brace-expansion@^2.0.2:
   version "2.1.1"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz"
   integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
@@ -1664,7 +1760,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0:
   version "4.27.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz"
   integrity sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==
@@ -1826,11 +1922,6 @@ create-jest@^29.7.0:
     jest-config "^29.7.0"
     jest-util "^29.7.0"
     prompts "^2.0.1"
-
-crelt@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz"
-  integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
 
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -2355,7 +2446,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-"eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9, "eslint@^9 || ^10", eslint@>=6.0.0, eslint@>=8, eslint@>=8.23.0, eslint@>=9.0.0, eslint@9.39.1:
+eslint@9.39.1, eslint@>=9.0.0:
   version "9.39.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz"
   integrity sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==
@@ -2494,7 +2585,7 @@ fast-glob@^3.3.2:
     merge2 "^1.3.0"
     micromatch "^4.0.8"
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2562,15 +2653,7 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-up@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
-
-find-up@^4.1.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -2615,6 +2698,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -2732,17 +2820,7 @@ glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
-  integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
-
-globals@^15.8.0:
-  version "15.15.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz"
-  integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
-
-globals@14.0.0:
+globals@14.0.0, globals@^14.0.0:
   version "14.0.0"
   resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
@@ -2751,6 +2829,11 @@ globals@17.6.0:
   version "17.6.0"
   resolved "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz"
   integrity sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==
+
+globals@^15.8.0:
+  version "15.15.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz"
+  integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
 
 globalthis@^1.0.4:
   version "1.0.4"
@@ -3291,7 +3374,7 @@ jest-each@^29.7.0:
     jest-util "^29.7.0"
     pretty-format "^29.7.0"
 
-jest-environment-node@^29.7.0, jest-environment-node@29.7.0:
+jest-environment-node@29.7.0, jest-environment-node@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz"
   integrity sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==
@@ -3387,7 +3470,7 @@ jest-resolve-dependencies@^29.7.0:
     jest-regex-util "^29.6.3"
     jest-snapshot "^29.7.0"
 
-jest-resolve@*, jest-resolve@^29.7.0:
+jest-resolve@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz"
   integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
@@ -3483,7 +3566,7 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-"jest-util@^29.0.0 || ^30.0.0", jest-util@^29.7.0:
+jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz"
   integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
@@ -3531,7 +3614,7 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-"jest@^29.0.0 || ^30.0.0", jest@29.7.0:
+jest@29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
@@ -4187,14 +4270,7 @@ minimatch@^8.0.0:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.4:
-  version "9.0.9"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz"
-  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
-  dependencies:
-    brace-expansion "^2.0.2"
-
-minimatch@^9.0.5:
+minimatch@^9.0.4, minimatch@^9.0.5:
   version "9.0.9"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz"
   integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
@@ -4216,7 +4292,7 @@ moment@2.29.4:
   resolved "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
-ms@^2.1.1, ms@2.1.2:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -4661,19 +4737,7 @@ resolve@^1.20.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^2.0.0-next.5:
-  version "2.0.0-next.7"
-  resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz"
-  integrity sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==
-  dependencies:
-    es-errors "^1.3.0"
-    is-core-module "^2.16.2"
-    node-exports-info "^1.6.0"
-    object-keys "^1.1.1"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
-resolve@^2.0.0-next.6:
+resolve@^2.0.0-next.5, resolve@^2.0.0-next.6:
   version "2.0.0-next.7"
   resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz"
   integrity sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==
@@ -4749,12 +4813,7 @@ safe-regex@^2.1.1:
   dependencies:
     regexp-tree "~0.1.1"
 
-semver@^6.3.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -5006,11 +5065,6 @@ strnum@^2.2.3:
   dependencies:
     anynum "^1.0.0"
 
-style-mod@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz"
-  integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
-
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
@@ -5106,7 +5160,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.6.2, tslib@2.8.1:
+tslib@2.8.1, tslib@^2.6.2:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -5185,7 +5239,7 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.1.0"
     reflect.getprototypeof "^1.0.10"
 
-typescript-eslint@^8.35.1, typescript-eslint@8.46.3:
+typescript-eslint@8.46.3, typescript-eslint@^8.35.1:
   version "8.46.3"
   resolved "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.3.tgz"
   integrity sha512-bAfgMavTuGo+8n6/QQDVQz4tZ4f7Soqg53RbrlZQEoAltYop/XR4RAts/I0BrO3TTClTSTFJ0wYbla+P8cEWJA==
@@ -5195,15 +5249,15 @@ typescript-eslint@^8.35.1, typescript-eslint@8.46.3:
     "@typescript-eslint/typescript-estree" "8.46.3"
     "@typescript-eslint/utils" "8.46.3"
 
-"typescript@>=4.3 <7", typescript@>=4.8.4, "typescript@>=4.8.4 <6.0.0", typescript@5.9.3:
-  version "5.9.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
-
 typescript@5.4.5:
   version "5.4.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz"
   integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+
+typescript@5.9.3:
+  version "5.9.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 uglify-js@^3.1.4:
   version "3.19.3"
@@ -5313,11 +5367,6 @@ vfile@^6.0.0:
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
-
-w3c-keyname@^2.2.4:
-  version "2.2.8"
-  resolved "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz"
-  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
## Summary

Adds **OpenAI** as a fifth TTS provider, mirroring the existing providers so all player/playback/download features work identically.

## What's included

- **`OpenAiSpeechService`** — plain-text input (no SSML), POSTs to `/v1/audio/speech` with a Bearer token via `requestUrl` (bypasses CORS, keeps the key out of fetch/XHR), concatenates the returned MP3 chunks. Credential validation probes `/v1/models`. Provider-specific friendly error messages, consistent with the other services.
- **Model dropdown** (like ElevenLabs): `gpt-4o-mini-tts` (default), `tts-1` (fast), `tts-1-hd` (quality).
- **Built-in voice catalog** limited to the voices supported across every selectable model (alloy, ash, coral, echo, fable, onyx, nova, sage, shimmer), so switching the model never invalidates the chosen voice.
- **Full wiring**: provider factory, settings tab (`displayOpenAISettings` + provider dropdown), player provider dropdown, `persistActiveVoice`; new `OPENAI_API_KEY` / `OPENAI_VOICE` / `OPENAI_MODEL` settings with defaults.
- **DRY cleanup**: extracted the shared plain-text chunker into `textChunker.ts` and reused it in both ElevenLabs and OpenAI (removes duplicated chunking logic).
- **What's New modal** extended with OpenAI (all existing entries kept).
- **README** updated (intro, highlights, settings table, provider comparison table, "Connecting a Provider").

## Design notes

- **Speed** is applied client-side via the audio element's `playbackRate` (as with the other providers), so no `speed` param is sent to the API — this also sidesteps the known `gpt-4o-mini-tts` speed-param issue.
- The OpenAI-specific `instructions` (voice steering, `gpt-4o-mini-tts` only) is intentionally left out to keep parity with the other providers; it can be added later as an optional setting.

## Testing

- `npm run build` (typecheck + bundle): clean
- `eslint` + `prettier`: clean
- `jest`: **111/111 passing** — new `tests/openai.unit.test.ts` (basics, validation, synthesis, chunking, factory) and `tests/text-chunker.unit.test.ts`

> Note: verified via tests/typecheck/build only — the live synthesis call has not been exercised against the real OpenAI API (no GUI/key in this environment). Worth a quick manual check with a valid key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVD1tWSWBTUwLcaPNTvdg8)_