### PR TITLE
docs: reframe provider messaging to "bring your own provider"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Obsidian Voice — listen to your notes in natural, lifelike speech with AWS Polly, ElevenLabs, Google Cloud, Azure Speech, or OpenAI](./assets/hero.png)
 
-Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian Voice Plugin reads your notes aloud in natural, lifelike speech — powered by your choice of **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI**. Listen with a dedicated player, jump between notes like chapters, change the speed on the fly, and save audio offline — with your credentials kept private in your own account.
+Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian Voice Plugin reads your notes aloud in natural, lifelike speech — using the text-to-speech provider you already have. It supports all the major engines — **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, and **Azure Speech** — so you can listen with whichever one you prefer. Listen with a dedicated player, jump between notes like chapters, change the speed on the fly, and save audio offline — with your credentials kept private in your own account.
 
 ## Table of Contents
 
@@ -11,7 +11,7 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 - [Feature Tour](#feature-tour)
 - [Settings](#settings)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
-- [Choose Your Speech Provider](#choose-your-speech-provider)
+- [Bring Your Own Provider](#bring-your-own-provider)
 - [Getting Started](#getting-started)
 - [Connecting a Provider](#connecting-a-provider)
 - [Troubleshooting & Help](#troubleshooting--help)
@@ -19,7 +19,7 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 ## Highlights
 
 - **A real audiobook player** — open the Voice player, see your notes as chapters, and play, skip, and repeat just like a podcast app.
-- **Five engines, one experience** — switch between **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, and **OpenAI** anytime. Every feature works the same on all of them.
+- **Bring your own provider** — Voice supports all the major text-to-speech engines (**AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, and **Azure Speech**), so you can listen with whichever one you already use. Every feature works the same on all of them.
 - **Listen in seconds** — turn any note into lifelike speech straight from the ribbon, a command, or the player.
 - **Designed for every device** — the same experience on desktop, iOS, and Android, with a touch-friendly mobile player and control bar.
 - **Own your audio** — download MP3 files, auto-embed them into your note, and keep an offline archive.
@@ -158,9 +158,9 @@ Voice ships **16 commands** you can bind to any hotkey. No keys are assigned by 
 | Open the player.                                                          | Open the Voice player pane               |
 | Show what's new.                                                          | Reopen the latest "What's New" note      |
 
-## Choose Your Speech Provider
+## Bring Your Own Provider
 
-Pick **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI** from the **Speech Provider** dropdown in settings. Each provider keeps its own credentials and voice list; everything else — tempo, rewind/fast-forward intervals, downloads, auto-save, and the content toggles — works identically. After entering your credentials, press **Test Credentials** to confirm everything is connected.
+Voice is built to work with the provider you already use. For a long time it was AWS Polly only — the goal now is to support all the common text-to-speech engines, so you can bring your own. Pick **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, or **Azure Speech** from the **Speech Provider** dropdown in settings. Each provider keeps its own credentials and voice list; everything else — tempo, rewind/fast-forward intervals, downloads, auto-save, and the content toggles — works identically. After entering your credentials, press **Test Credentials** to confirm everything is connected.
 
 |                 | **AWS Polly**                       | **ElevenLabs**                                      | **Google Cloud**                                  | **Azure Speech**                    | **OpenAI**                                    |
 | --------------- | ----------------------------------- | --------------------------------------------------- | ------------------------------------------------- | ----------------------------------- | --------------------------------------------- |
@@ -179,7 +179,7 @@ Pick **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **Ope
 
 ## Connecting a Provider
 
-Choose one provider to start — you can switch anytime.
+Start with the provider you already have — you can switch anytime.
 
 **AWS Polly** — In **Settings → Voice**, choose **AWS Polly**, select your region, paste your **Access Key ID** and **Secret Access Key**, and press **Test Credentials**. For a step-by-step guide to creating a dedicated AWS key, see [Advanced: AWS Polly Setup](./TROUBLESHOOTING.md#advanced-aws-polly-setup).
 

--- a/src/utils/whatsNew.ts
+++ b/src/utils/whatsNew.ts
@@ -28,7 +28,7 @@ Voice now has a full **audiobook-style player** — and it lives in the right si
 - **Browse audio across your vault** — a folder picker lets you jump between any folders that contain audio, right from the player.
 - **Transport controls** — play / pause, previous / next, rewind, fast-forward, a draggable progress bar, and on-the-fly speed.
 - **Read this note & download** — generate speech and save an MP3 without leaving the player.
-- **Switch provider & voice** — change between AWS Polly, ElevenLabs, Google Cloud, Azure Speech, and OpenAI directly in the player.
+- **Bring your own provider** — pick AWS Polly, ElevenLabs, OpenAI, Google Cloud, or Azure Speech (and the voice) right in the player.
 
 ## ✨ Everything you need to know
 
@@ -39,12 +39,14 @@ Voice now has a full **audiobook-style player** — and it lives in the right si
 - **Collapsible, audiobook-style player** with chapters, transport controls, scrubber, and repeat modes (off / one / all).
 - **Configurable rewind & fast-forward** intervals (1–60 seconds each).
 
-**More engines, more voices**
+**Bring your own provider**
 
-- **ElevenLabs** support — premade & multilingual voices.
-- **Google Cloud Text-to-Speech** support, plus extra hotkey commands.
-- **Azure AI Speech** support — neural voices across many languages.
-- **OpenAI** support — built-in voices (Alloy, Nova, …) with GPT-4o mini TTS.
+Voice started out as AWS Polly only — now it supports all the major engines, so you can listen with the provider you already use:
+
+- **ElevenLabs** — premade & multilingual voices.
+- **OpenAI** — built-in voices (Alloy, Nova, …) with GPT-4o mini TTS.
+- **Google Cloud Text-to-Speech** — plus extra hotkey commands.
+- **Azure AI Speech** — neural voices across many languages.
 
 **Your audio files**
 


### PR DESCRIPTION
## Summary

Reframes the provider messaging from "switch between providers" to a **bring-your-own-provider** positioning: Voice supports all the common TTS engines so users can listen with the provider they already have. (Voice was AWS Polly-only for a long time; the goal now is broad provider support.)

## Changes

**README.md**
- Intro reworded to lead with "using the text-to-speech provider you already have… supports all the major engines."
- Highlights bullet: _Five engines, one experience — switch between…_ → **Bring your own provider** — supports all the major engines so you can use whichever one you already have.
- Section **"Choose Your Speech Provider" → "Bring Your Own Provider"** (TOC link updated), with a new intro that tells the AWS Polly → all-providers story.
- "Connecting a Provider" lead-in: _Start with the provider you already have — you can switch anytime._

**What's New modal (`src/utils/whatsNew.ts`)**
- In-player bullet reframed to **Bring your own provider**.
- Engines section retitled **Bring your own provider** with a short framing sentence (OpenAI moved up).

Deliberately left untouched where "switch" means something else (e.g. the **Switch to the next speaker** command and mobile **voice switching** = cycling voices).

## Testing
- What's New unit tests: 6/6 passing
- `prettier` + `build`: clean

> Copy/marketing wording — easy to tweak if a different tone or a punchier tagline is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVD1tWSWBTUwLcaPNTvdg8)_