### PR TITLE
feat: player progress, folder paths, track rename, acronym fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ The Voice player is the heart of the plugin: an audiobook-style pane that turns 
 
 - **Always within reach** — the player is docked in the right sidebar (next to Backlinks and Outline) right after install, so it's there whenever you need it. On mobile it opens as a full-screen pane.
 - **Chapters from your folder** — every MP3 saved next to the current note appears as a numbered chapter. Listen to a whole folder like an audiobook, and the chapter you're hearing is highlighted.
-- **Folder picker** — jump between any folders in your vault that contain audio straight from the player, and the chapter list updates to that folder's MP3s. It follows the note you're viewing by default; turn off **Folder Picker Follows Active Note** in settings to keep your chosen folder while you browse.
+- **Folder picker** — jump between any folders in your vault that contain audio straight from the player, and the chapter list updates to that folder's MP3s. Each folder is shown leaf-first with its path trailing to the right, so same-named folders stay distinct. It follows the note you're viewing by default; turn off **Folder Picker Follows Active Note** in settings to keep your chosen folder while you browse.
+- **Rename tracks** — hover a chapter and click the pencil to rename the MP3 right from the player. The file is renamed in place (same folder, `.mp3` kept) and embeds are updated automatically.
 - **Transport controls** — previous / next chapter, rewind, play / pause, and fast-forward, with a draggable progress bar and live time display.
-- **Read this note** — generate speech for the note you're viewing with a single click.
+- **Read this note** — generate speech for the note you're viewing with a single click; the play button spins and a progress bar fills up while the audio is synthesized.
 - **Repeat modes** — cycle through _off → repeat one → repeat all_ to loop a single chapter or play through every chapter in the folder.
 - **Speed on the spot** — nudge playback from 0.5× to 2.0× with the − / + buttons.
 - **Download** — save the current audio as an MP3 right from the player.

--- a/src/processors/MarkdownToTextProcessor.ts
+++ b/src/processors/MarkdownToTextProcessor.ts
@@ -19,6 +19,7 @@ import type { ProcessorConfig } from "../types/ProcessorTypes";
 import { DEFAULT_CONFIG } from "./config/DefaultConfig";
 import { cleanProcessor } from "./pipeline/CleanProcessor";
 import { serializeToText } from "./pipeline/TextSerializer";
+import { titleCaseAcronyms } from "./pipeline/acronyms";
 
 export class MarkdownToTextProcessor {
   private config: ProcessorConfig;
@@ -61,7 +62,12 @@ export class MarkdownToTextProcessor {
     cleanProcessor(cleanOptions)(ast);
 
     // Stage 3: Serialize to spoken text (with structural pause tags)
-    return serializeToText(ast, { pauseTags: this.pauseTags });
+    const text = serializeToText(ast, { pauseTags: this.pauseTags });
+
+    // Stage 4: When acronyms should not be spelled out, title-case them so the
+    // engine reads them as a word (consistent with the SSML pipeline). Engines
+    // like Google otherwise spell uppercase tokens by default.
+    return this.config.spellOutAcronyms ? text : titleCaseAcronyms(text);
   }
 
   updateConfig(config: Partial<ProcessorConfig>): void {

--- a/src/processors/pipeline/EnhanceProcessor.ts
+++ b/src/processors/pipeline/EnhanceProcessor.ts
@@ -22,6 +22,7 @@ import type {
   SSMLSayAs,
   SSMLSub,
 } from "../../types/SSMLNodes";
+import { ACRONYM_PATTERN, titleCaseAcronyms } from "./acronyms";
 
 /**
  * Modification to apply after tree traversal
@@ -50,11 +51,6 @@ const ABBREVIATIONS: Record<string, string> = {
   "i.e.": "that is",
   "vs.": "versus",
 };
-
-/**
- * Pattern to detect acronyms (2+ consecutive uppercase letters)
- */
-const ACRONYM_PATTERN = /\b[A-Z]{2,}\b/g;
 
 /**
  * Pattern to detect numbers (including formatted numbers)
@@ -233,6 +229,13 @@ interface TextSegment {
  * Returns array of nodes to replace the original text node
  */
 function enhanceText(textNode: Text, options: EnhanceProcessorOptions): Node[] {
+  // When acronyms should NOT be spelled out, title-case them up front (NASA →
+  // Nasa) so the engine reads them as a word. This preserves length, so the
+  // segment offsets computed below stay valid. When they SHOULD be spelled out,
+  // the say-as branch further down handles it instead.
+  if (!options.spellOutAcronyms) {
+    textNode.value = titleCaseAcronyms(textNode.value);
+  }
   const text = textNode.value;
   const segments: TextSegment[] = [];
 

--- a/src/processors/pipeline/acronyms.ts
+++ b/src/processors/pipeline/acronyms.ts
@@ -1,0 +1,26 @@
+/**
+ * Acronym handling shared by the SSML and plain-text pipelines.
+ *
+ * When "Spell Out Acronyms" is ON, the SSML pipeline wraps acronyms in
+ * <say-as interpret-as="characters"> so they are read letter by letter. When it
+ * is OFF, we title-case acronyms (NASA → Nasa) so every TTS engine reads them
+ * as a word instead of spelling them out — some engines (e.g. Google) spell
+ * uppercase tokens by default, so this keeps pronunciation consistent across
+ * providers, matching AWS Polly's natural reading.
+ */
+
+/** Matches acronyms: runs of 2+ consecutive uppercase letters. */
+export const ACRONYM_PATTERN = /\b[A-Z]{2,}\b/g;
+
+/** Title-case a single all-caps acronym token (NASA → Nasa). */
+export function toTitleCaseAcronym(word: string): string {
+  return word.charAt(0) + word.slice(1).toLowerCase();
+}
+
+/**
+ * Title-case every all-caps acronym in the text. The transform preserves
+ * length, so callers that rely on character offsets into the string stay valid.
+ */
+export function titleCaseAcronyms(text: string): string {
+  return text.replace(ACRONYM_PATTERN, (match) => toTitleCaseAcronym(match));
+}

--- a/src/service/BaseSpeechService.ts
+++ b/src/service/BaseSpeechService.ts
@@ -35,6 +35,9 @@ export abstract class BaseSpeechService implements SpeechProvider {
   // How many seconds the rewind / fast-forward controls jump
   protected rewindSeconds: number = DEFAULT_SKIP_SECONDS;
   protected forwardSeconds: number = DEFAULT_SKIP_SECONDS;
+  // Last reported synthesis progress (0..1), exposed via getProgress() for
+  // pollers such as the Voice player's loading bar.
+  protected lastProgress: number = 0;
 
   constructor(voice: string, speed?: number) {
     this.voice = voice;
@@ -234,6 +237,7 @@ export abstract class BaseSpeechService implements SpeechProvider {
     const requestId = `req_${Date.now()}_${Math.random().toString(36).substring(2, 15)}`;
     this.currentRequestId = requestId;
     this.abortController = new AbortController();
+    this.lastProgress = 0;
 
     return requestId;
   }
@@ -291,10 +295,15 @@ export abstract class BaseSpeechService implements SpeechProvider {
   }
 
   protected reportProgress(current: number, total: number): void {
+    const progress = total > 0 ? current / total : 0;
+    this.lastProgress = Math.min(1, Math.max(0, progress));
     if (this.progressCallback) {
-      const progress = total > 0 ? current / total : 0;
-      this.progressCallback(Math.min(1, Math.max(0, progress)));
+      this.progressCallback(this.lastProgress);
     }
+  }
+
+  getProgress(): number {
+    return this.lastProgress;
   }
 
   protected reportError(error: unknown): void {

--- a/src/service/SpeechProvider.ts
+++ b/src/service/SpeechProvider.ts
@@ -76,6 +76,9 @@ export interface SpeechProvider {
   setProgressCallback(callback: (progress: number) => void): void;
   setErrorCallback(callback: (error: string) => void): void;
 
+  /** Last reported synthesis progress (0..1). Useful for pollers like the player. */
+  getProgress(): number;
+
   // Caching / download
   getLastGeneratedAudio(filePath?: string): Blob | null;
   clearCachedAudio(): void;

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -1,4 +1,11 @@
-import { ItemView, WorkspaceLeaf, TFile, setIcon } from "obsidian";
+import {
+  ItemView,
+  WorkspaceLeaf,
+  TFile,
+  setIcon,
+  Notice,
+  normalizePath,
+} from "obsidian";
 import type { Voice } from "../utils/VoicePlugin";
 import type { TtsProvider } from "../settings/VoiceSettings";
 import {
@@ -56,6 +63,7 @@ export class VoicePlayerView extends ItemView {
   private folderSelect: HTMLSelectElement;
   private codeBtn: HTMLElement;
   private loadingBarEl: HTMLElement;
+  private loadingFillEl: HTMLElement;
 
   private isScrubbing = false;
   private currentChapterPath: string | null = null;
@@ -290,7 +298,9 @@ export class VoicePlayerView extends ItemView {
 
     // Loading bar (indeterminate), shown while a note is being processed.
     this.loadingBarEl = root.createDiv({ cls: "voice-player-loading" });
-    this.loadingBarEl.createDiv({ cls: "voice-player-loading-fill" });
+    this.loadingFillEl = this.loadingBarEl.createDiv({
+      cls: "voice-player-loading-fill",
+    });
 
     this.refreshControls();
   }
@@ -564,8 +574,102 @@ export class VoicePlayerView extends ItemView {
       this.registerDomEvent(item, "click", () =>
         this.playChapter(chapter.path),
       );
+
+      // Rename control: edit the MP3's file name (kept in the same folder, the
+      // .mp3 extension is preserved). Stops propagation so it doesn't play.
+      const editBtn = item.createDiv({
+        cls: "voice-player-chapter-edit",
+        attr: { "aria-label": "Rename track" },
+      });
+      setIcon(editBtn, "pencil");
+      this.registerDomEvent(editBtn, "click", (evt) => {
+        evt.stopPropagation();
+        this.beginRenameChapter(item, chapter);
+      });
     });
     this.highlightCurrentChapter();
+  }
+
+  /**
+   * Replace a chapter's name with an inline text field so the user can rename
+   * the underlying MP3. Enter/blur commits, Escape cancels.
+   */
+  private beginRenameChapter(item: HTMLElement, chapter: ChapterFile): void {
+    const nameEl = item.querySelector<HTMLElement>(
+      ".voice-player-chapter-name",
+    );
+    if (!nameEl) {
+      return;
+    }
+    const input = createEl("input", {
+      cls: "voice-player-chapter-rename",
+      attr: { type: "text" },
+    });
+    input.value = chapter.name;
+    nameEl.replaceWith(input);
+    input.focus();
+    input.select();
+
+    let settled = false;
+    const commit = () => {
+      if (settled) return;
+      settled = true;
+      void this.commitRenameChapter(chapter, input.value);
+    };
+    const cancel = () => {
+      if (settled) return;
+      settled = true;
+      this.refreshContext();
+    };
+
+    this.registerDomEvent(input, "click", (evt) => evt.stopPropagation());
+    this.registerDomEvent(input, "keydown", (evt) => {
+      if (evt.key === "Enter") {
+        evt.preventDefault();
+        commit();
+      } else if (evt.key === "Escape") {
+        evt.preventDefault();
+        cancel();
+      }
+    });
+    this.registerDomEvent(input, "blur", () => commit());
+  }
+
+  /**
+   * Rename the chapter's MP3 on disk to the new base name, keeping it in the
+   * same folder and preserving the .mp3 extension. Uses fileManager so embeds
+   * in notes are updated automatically.
+   */
+  private async commitRenameChapter(
+    chapter: ChapterFile,
+    rawName: string,
+  ): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(chapter.path);
+    const newBase = rawName.trim();
+    if (!(file instanceof TFile) || !newBase || newBase === chapter.name) {
+      this.refreshContext();
+      return;
+    }
+    if (/[\\/:*?"<>|]/.test(newBase)) {
+      new Notice("That file name contains characters that aren't allowed.");
+      this.refreshContext();
+      return;
+    }
+
+    const folder = normalizeFolderPath(file.parent?.path ?? "/");
+    const dir = folder === "/" ? "" : `${folder}/`;
+    const newPath = normalizePath(`${dir}${newBase}.${file.extension}`);
+    try {
+      await this.app.fileManager.renameFile(file, newPath);
+      if (this.currentChapterPath === chapter.path) {
+        this.currentChapterPath = newPath;
+      }
+    } catch (error) {
+      new Notice(
+        `Could not rename: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    this.refreshContext();
   }
 
   private playChapter(path: string): void {
@@ -698,13 +802,24 @@ export class VoicePlayerView extends ItemView {
     }
     this.durationEl.setText(formatTime(duration));
 
-    setIcon(this.playPauseBtn, provider.isPlaying() ? "pause" : "play");
     this.speedEl.setText(`${provider.getSpeed().toFixed(1)}×`);
 
-    // Loading feedback while a note is being synthesized: show the bottom bar
+    // Loading feedback while a note is being synthesized: grow the bottom bar to
+    // the real synthesis progress, spin the play button (like the status bar),
     // and animate (and disable) the "Read this note" button.
     const loading = provider.isOperationInProgress();
     this.loadingBarEl.toggleClass("is-visible", loading);
+    if (loading) {
+      const pct = Math.round(provider.getProgress() * 100);
+      this.loadingFillEl.setCssProps({ "--voice-progress": `${pct}%` });
+      if (!this.playPauseBtn.hasClass("rotating-icon")) {
+        this.playPauseBtn.addClass("rotating-icon");
+        setIcon(this.playPauseBtn, "refresh-ccw");
+      }
+    } else {
+      this.playPauseBtn.removeClass("rotating-icon");
+      setIcon(this.playPauseBtn, provider.isPlaying() ? "pause" : "play");
+    }
     this.readBtn.toggleClass("is-loading", loading);
     this.readBtn.disabled = loading;
     this.readBtn.setText(loading ? "Reading…" : "Read this note");

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -53,8 +53,13 @@ export class TextSpeaker {
       ...contentOptions,
     });
 
-    // Plain-text pipeline (ElevenLabs and other non-SSML providers)
-    this.textProcessor = new MarkdownToTextProcessor(contentOptions);
+    // Plain-text pipeline (ElevenLabs and other non-SSML providers). It also
+    // needs the acronym setting so it can title-case acronyms when spell-out is
+    // off, keeping pronunciation consistent with the SSML providers.
+    this.textProcessor = new MarkdownToTextProcessor({
+      ...contentOptions,
+      spellOutAcronyms: this.spellOutAcronyms,
+    });
   }
 
   async speakText(speed?: number): Promise<void> {

--- a/src/utils/chapters.ts
+++ b/src/utils/chapters.ts
@@ -42,10 +42,26 @@ export function folderDisplayName(path: string): string {
 }
 
 /**
+ * Display label for a folder, with its own name first and parent folders to the
+ * right, up to the top-level folder (e.g. "Projects/Audiobooks/Part 1" →
+ * "Part 1 / Audiobooks / Projects"). Putting the actual folder on the left keeps
+ * the most relevant part visible when the dropdown truncates, while the trail to
+ * the right disambiguates folders that share the same name. The vault root
+ * renders as "/".
+ */
+export function folderPathLabel(path: string): string {
+  const normalized = normalizeFolderPath(path);
+  if (normalized === "/") {
+    return "/";
+  }
+  return normalized.split("/").reverse().join(" / ");
+}
+
+/**
  * Build the list of folders that contain at least one MP3, derived from a flat
- * list of MP3 paths. Folders are de-duplicated and sorted naturally by their
- * display name (case-insensitively), so the player's folder picker only ever
- * offers directories that actually hold audio.
+ * list of MP3 paths. Folders are de-duplicated and sorted by their full path
+ * (so the hierarchy groups together), with a leaf-first display label, so the
+ * player's folder picker only ever offers directories that actually hold audio.
  */
 export function listMp3Folders(mp3Paths: string[]): Mp3Folder[] {
   const folderPaths = new Set<string>();
@@ -55,9 +71,9 @@ export function listMp3Folders(mp3Paths: string[]): Mp3Folder[] {
     folderPaths.add(normalizeFolderPath(folder));
   }
   return [...folderPaths]
-    .map((path) => ({ path, name: folderDisplayName(path) }))
+    .map((path) => ({ path, name: folderPathLabel(path) }))
     .sort((a, b) =>
-      a.name.localeCompare(b.name, undefined, {
+      a.path.localeCompare(b.path, undefined, {
         numeric: true,
         sensitivity: "base",
       }),

--- a/styles.css
+++ b/styles.css
@@ -753,6 +753,36 @@
   font-weight: 600;
 }
 
+/* Rename control on each chapter row */
+.voice-player-chapter-edit {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-s);
+  cursor: pointer;
+  color: var(--text-faint);
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.voice-player-chapter:hover .voice-player-chapter-edit {
+  opacity: 1;
+}
+
+.voice-player-chapter-edit:hover {
+  color: var(--text-normal);
+  background: var(--background-modifier-hover);
+}
+
+.voice-player-chapter-rename {
+  flex: 1;
+  min-width: 0;
+  font-size: inherit;
+}
+
 /* Provider / voice selectors + read-code-blocks toggle */
 .voice-player-options {
   display: flex;
@@ -842,7 +872,8 @@
   }
 }
 
-/* Indeterminate loading bar, pinned to the bottom of the panel */
+/* Determinate loading bar, pinned to the bottom of the panel. The fill grows
+   to the real synthesis progress via the --voice-progress custom property. */
 .voice-player-loading {
   margin-top: auto;
   height: 3px;
@@ -858,18 +889,9 @@
 }
 
 .voice-player-loading-fill {
-  width: 40%;
+  width: var(--voice-progress, 0%);
   height: 100%;
   border-radius: 3px;
   background: var(--interactive-accent);
-  animation: voice-player-indeterminate 1.1s ease-in-out infinite;
-}
-
-@keyframes voice-player-indeterminate {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(350%);
-  }
+  transition: width 0.2s ease;
 }

--- a/tests/acronyms.unit.test.ts
+++ b/tests/acronyms.unit.test.ts
@@ -1,0 +1,40 @@
+import {
+  titleCaseAcronyms,
+  toTitleCaseAcronym,
+} from "../src/processors/pipeline/acronyms";
+
+describe("Unit Tests - Acronym helpers", () => {
+  describe("toTitleCaseAcronym", () => {
+    test("title-cases an all-caps token", () => {
+      expect(toTitleCaseAcronym("NASA")).toBe("Nasa");
+      expect(toTitleCaseAcronym("FBI")).toBe("Fbi");
+    });
+
+    test("preserves the original length", () => {
+      expect(toTitleCaseAcronym("API")).toHaveLength(3);
+    });
+  });
+
+  describe("titleCaseAcronyms", () => {
+    test("title-cases acronyms inside a sentence", () => {
+      expect(titleCaseAcronyms("The NASA and FBI report")).toBe(
+        "The Nasa and Fbi report",
+      );
+    });
+
+    test("leaves single uppercase letters and normal words untouched", () => {
+      expect(titleCaseAcronyms("A normal sentence with I")).toBe(
+        "A normal sentence with I",
+      );
+    });
+
+    test("does not change lowercase or mixed-case words", () => {
+      expect(titleCaseAcronyms("iPhone and macOS")).toBe("iPhone and macOS");
+    });
+
+    test("preserves the overall length so offsets stay valid", () => {
+      const input = "Use the API now";
+      expect(titleCaseAcronyms(input)).toHaveLength(input.length);
+    });
+  });
+});

--- a/tests/chapters.unit.test.ts
+++ b/tests/chapters.unit.test.ts
@@ -3,6 +3,7 @@ import {
   chapterName,
   listMp3Folders,
   folderDisplayName,
+  folderPathLabel,
   normalizeFolderPath,
 } from "../src/utils/chapters";
 
@@ -76,15 +77,32 @@ describe("Unit Tests - Chapter helpers", () => {
     });
   });
 
+  describe("folderPathLabel", () => {
+    test("shows the folder first and parents to the right", () => {
+      expect(folderPathLabel("Projects/Audiobooks/Part 1")).toBe(
+        "Part 1 / Audiobooks / Projects",
+      );
+    });
+
+    test("leaves a single-segment folder unchanged", () => {
+      expect(folderPathLabel("audio")).toBe("audio");
+    });
+
+    test("renders the vault root as a slash", () => {
+      expect(folderPathLabel("/")).toBe("/");
+      expect(folderPathLabel("")).toBe("/");
+    });
+  });
+
   describe("listMp3Folders", () => {
-    test("returns only folders that contain MP3s, de-duplicated", () => {
+    test("returns only folders that contain MP3s, de-duplicated, leaf-first", () => {
       const result = listMp3Folders([
         "notes/audio/a.mp3",
         "notes/audio/b.mp3",
         "podcasts/c.mp3",
       ]);
       expect(result).toEqual([
-        { path: "notes/audio", name: "audio" },
+        { path: "notes/audio", name: "audio / notes" },
         { path: "podcasts", name: "podcasts" },
       ]);
     });
@@ -94,13 +112,13 @@ describe("Unit Tests - Chapter helpers", () => {
       expect(result).toEqual([{ path: "/", name: "/" }]);
     });
 
-    test("sorts folders naturally by display name", () => {
+    test("sorts folders naturally by full path", () => {
       const result = listMp3Folders([
         "Part 10/a.mp3",
         "Part 2/b.mp3",
         "Part 1/c.mp3",
       ]);
-      expect(result.map((f) => f.name)).toEqual([
+      expect(result.map((f) => f.path)).toEqual([
         "Part 1",
         "Part 2",
         "Part 10",


### PR DESCRIPTION
## Summary

Five Voice player improvements/fixes:

1. **Determinate loading progress** — the "Read this note" loading bar now grows to the real synthesis progress (via a new `getProgress()` on the provider), instead of an indeterminate animation.
2. **Folder picker shows the path** — each folder is rendered leaf-first with its path trailing to the right (e.g. `Part 1 / Audiobooks / Projects`) and sorted by full path, so same-named folders are unambiguous; long labels truncate.
3. **Rename tracks** — a pencil control on each chapter renames the MP3 in place (same folder, `.mp3` preserved) via `fileManager.renameFile`, so embeds in notes update automatically. Inline edit: Enter/blur commits, Escape cancels; invalid characters are rejected.
4. **Play button spinner** — while synthesizing, the player's play button spins with an in-progress icon (like the status bar), then returns to pause/play.
5. **Spell Out Acronyms fix** — when the toggle is **off**, acronyms are title-cased (`NASA` → `Nasa`) in **both** the SSML and plain-text pipelines, so engines that spell uppercase tokens by default (e.g. Google) read them as words — matching AWS Polly across all providers. (Chosen trade-off: always-spelled acronyms like FBI/API are read as words when off.)

## Implementation notes

- New `getProgress()` on `SpeechProvider` / `BaseSpeechService` (stores last reported progress; reset on `startOperation`).
- New shared `processors/pipeline/acronyms.ts` (`titleCaseAcronyms`, length-preserving) used by `EnhanceProcessor` (SSML) and `MarkdownToTextProcessor` (text); `TextSpeaker` now passes the acronym setting to the text pipeline.
- Folder labels via a new `folderPathLabel` in `chapters.ts`; `listMp3Folders` now sorts by full path.
- Determinate loading bar via a `--voice-progress` custom property; chapter rename UI + styles.

## Testing

- `npm run build` (typecheck + bundle): clean
- `eslint` + `prettier`: clean
- `jest`: **120/120 passing** — new `tests/acronyms.unit.test.ts`, extended `tests/chapters.unit.test.ts`

> Note: verified via tests/typecheck/build only — not exercised in a live Obsidian instance. The track rename (filesystem) and the engine acronym pronunciation are worth a quick manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVD1tWSWBTUwLcaPNTvdg8)_