### PR TITLE
fix: player transport controls respond on the first click

### DIFF
--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -161,10 +161,13 @@ export class VoicePlayerView extends ItemView {
       this.isScrubbing = false;
     });
 
-    // Transport
+    // Transport. These are real <button> elements (not divs) so a single
+    // click works even when the player pane isn't the focused leaf — Obsidian
+    // delivers the first click to native controls, whereas a plain div's click
+    // would be consumed by activating the pane (requiring a second click).
     const transport = root.createDiv({ cls: "voice-player-transport" });
 
-    this.prevTrackBtn = transport.createDiv({
+    this.prevTrackBtn = transport.createEl("button", {
       cls: "voice-player-btn voice-player-track",
       attr: { "aria-label": "Previous track" },
     });
@@ -173,8 +176,9 @@ export class VoicePlayerView extends ItemView {
       this.playPrevTrack(),
     );
 
-    const rewindBtn = transport.createDiv({
+    const rewindBtn = transport.createEl("button", {
       cls: "voice-player-btn voice-player-skip",
+      attr: { "aria-label": "Rewind" },
     });
     setIcon(rewindBtn, "rewind");
     rewindBtn
@@ -184,14 +188,16 @@ export class VoicePlayerView extends ItemView {
       this.provider().rewindAudio(),
     );
 
-    this.playPauseBtn = transport.createDiv({
+    this.playPauseBtn = transport.createEl("button", {
       cls: "voice-player-btn voice-player-play",
+      attr: { "aria-label": "Play / pause" },
     });
     setIcon(this.playPauseBtn, "play");
     this.registerDomEvent(this.playPauseBtn, "click", () => this.togglePlay());
 
-    const forwardBtn = transport.createDiv({
+    const forwardBtn = transport.createEl("button", {
       cls: "voice-player-btn voice-player-skip",
+      attr: { "aria-label": "Fast-forward" },
     });
     setIcon(forwardBtn, "fast-forward");
     forwardBtn
@@ -201,7 +207,7 @@ export class VoicePlayerView extends ItemView {
       this.provider().fastForwardAudio(),
     );
 
-    this.nextTrackBtn = transport.createDiv({
+    this.nextTrackBtn = transport.createEl("button", {
       cls: "voice-player-btn voice-player-track",
       attr: { "aria-label": "Next track" },
     });
@@ -240,11 +246,17 @@ export class VoicePlayerView extends ItemView {
     this.updateRepeatButton();
 
     const speedGroup = secondary.createDiv({ cls: "voice-player-speed" });
-    const slower = speedGroup.createDiv({ cls: "voice-player-speed-btn" });
+    const slower = speedGroup.createEl("button", {
+      cls: "voice-player-speed-btn",
+      attr: { "aria-label": "Slower" },
+    });
     setIcon(slower, "minus");
     this.registerDomEvent(slower, "click", () => this.changeSpeed(-0.1));
     this.speedEl = speedGroup.createSpan({ cls: "voice-player-speed-value" });
-    const faster = speedGroup.createDiv({ cls: "voice-player-speed-btn" });
+    const faster = speedGroup.createEl("button", {
+      cls: "voice-player-speed-btn",
+      attr: { "aria-label": "Faster" },
+    });
     setIcon(faster, "plus");
     this.registerDomEvent(faster, "click", () => this.changeSpeed(0.1));
 

--- a/styles.css
+++ b/styles.css
@@ -561,6 +561,14 @@
   cursor: pointer;
   color: var(--text-normal);
   border-radius: 50%;
+  /* Reset native <button> styling so these match their previous div look. */
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  box-shadow: none;
+  appearance: none;
   transition:
     transform 0.1s ease,
     background-color 0.15s ease;
@@ -682,6 +690,14 @@
   border-radius: var(--radius-s);
   cursor: pointer;
   color: var(--text-muted);
+  /* Reset native <button> styling so these match their previous div look. */
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  box-shadow: none;
+  appearance: none;
 }
 
 .voice-player-speed-btn:hover {


### PR DESCRIPTION
## Summary

Fixes the player needing **two clicks** to start playback when the pane isn't focused.

## Root cause

The transport controls (play/pause, prev/next, rewind, fast-forward) and the speed −/+ controls were plain `<div>`s. When the player pane isn't the focused leaf, Obsidian uses the first click to activate the pane, so a `div`'s click handler only fires on the **second** click. The "Read this note" control never had this problem because it's a real `<button>`.

## Fix

- Convert the transport and speed controls to native `<button>` elements (with `aria-label`s) so the first click is always delivered, even when the pane isn't focused — and they become keyboard-accessible (Tab / Enter / Space).
- Add a button style reset to `.voice-player-btn` / `.voice-player-speed-btn` so the controls look identical to before (the accent play button and all hover/active effects are preserved).

## Not changed

Chapter rows are also `div`s, but they already contain the rename `<button>` (a button can't be nested in a button), so they're intentionally left as-is. They can be made first-click-friendly separately via `tabindex`/`role="button"` if needed.

## Testing

- `npm run build` (typecheck + bundle): clean
- `eslint` + `prettier`: clean
- `jest`: **120/120 passing** (the view isn't unit-tested; logic unchanged)

> Note: verified via tests/typecheck/build only — the single-click behaviour on an unfocused pane is worth a quick manual check in Obsidian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVD1tWSWBTUwLcaPNTvdg8)_