### PR TITLE
fix(player): read active note on play, rename Read→Regenerate (#59)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,57 @@
+## Summary
+
+<!-- What does this PR do and why? 1–3 sentences. -->
+
+Closes #
+
+## Type of change
+
+<!-- Mark with an x. Match your commit prefix (Conventional Commits / semantic-release). -->
+
+- [ ] fix — bug fix (patch)
+- [ ] feat — new feature (minor)
+- [ ] docs — documentation only
+- [ ] refactor / chore — no user-facing change
+- [ ] BREAKING CHANGE (explain below)
+
+## Changes
+
+<!-- Bullet list of the key changes. Reference files/areas where helpful. -->
+
+-
+
+## Provider impact
+
+<!-- TTS is multi-provider. Tick every provider this PR affects, or "None". -->
+
+- [ ] None — no provider-specific behaviour changed
+- [ ] AWS Polly
+- [ ] ElevenLabs
+- [ ] OpenAI
+- [ ] Google Cloud
+- [ ] Azure Speech
+
+## Platform impact
+
+- [ ] Desktop
+- [ ] Mobile (iOS / Android)
+
+## How to test
+
+<!-- Concrete steps a reviewer can follow to verify the change. -->
+
+1.
+
+## Checklist
+
+- [ ] `npm run build` passes (tsc + esbuild)
+- [ ] `npm run lint:check` passes
+- [ ] `npm test` passes
+- [ ] Added/updated tests where it makes sense
+- [ ] Updated docs (README / TROUBLESHOOTING) if behaviour or settings changed
+- [ ] PR title follows Conventional Commits (e.g. `fix(player): …`)
+- [ ] No secrets/credentials committed
+
+## Screenshots / recordings
+
+<!-- For UI or player changes, before/after helps a lot. -->

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Voice player is the heart of the plugin: an audiobook-style pane that turns 
 - **Folder picker** — jump between any folders in your vault that contain audio straight from the player, and the chapter list updates to that folder's MP3s. Each folder is shown leaf-first with its path trailing to the right, so same-named folders stay distinct. It follows the note you're viewing by default; turn off **Folder Picker Follows Active Note** in settings to keep your chosen folder while you browse.
 - **Rename tracks** — hover a chapter and click the pencil to rename the MP3 right from the player. The file is renamed in place (same folder, `.mp3` kept) and embeds are updated automatically.
 - **Transport controls** — previous / next chapter, rewind, play / pause, and fast-forward, with a draggable progress bar and live time display.
-- **Read this note** — generate speech for the note you're viewing with a single click; the play button spins and a progress bar fills up while the audio is synthesized.
+- **Play & Regenerate** — press play to listen to the note you're viewing; if its audio is already loaded, play just resumes it. The **Regenerate** button (↻) forces a fresh synthesis from scratch — useful after you've edited the note or changed the voice. The play button spins and a progress bar fills up while audio is synthesized.
 - **Repeat modes** — cycle through _off → repeat one → repeat all_ to loop a single chapter or play through every chapter in the folder.
 - **Speed on the spot** — nudge playback from 0.5× to 2.0× with the − / + buttons.
 - **Download** — save the current audio as an MP3 right from the player.

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -57,6 +57,7 @@ export class VoicePlayerView extends ItemView {
   private speedEl: HTMLElement;
   private chaptersListEl: HTMLElement;
   private readBtn: HTMLButtonElement;
+  private readLabelEl: HTMLElement;
   private downloadBtn: HTMLButtonElement;
   private providerSelect: HTMLSelectElement;
   private voiceSelect: HTMLSelectElement;
@@ -219,9 +220,18 @@ export class VoicePlayerView extends ItemView {
     // Secondary row: read note + speed
     const secondary = root.createDiv({ cls: "voice-player-secondary" });
 
+    // Regenerate: force a fresh synthesis of the active note. The transport
+    // play button already reads the note when nothing matching is loaded, so
+    // this button's distinct job is to re-render from scratch (e.g. after the
+    // note changed) — hence the reload icon and "Regenerate" label.
     this.readBtn = secondary.createEl("button", {
       cls: "voice-player-read",
-      text: "Read this note",
+      attr: { "aria-label": "Regenerate audio for this note" },
+    });
+    setIcon(this.readBtn, "refresh-cw");
+    this.readLabelEl = this.readBtn.createSpan({
+      cls: "voice-player-read-label",
+      text: "Regenerate",
     });
     this.registerDomEvent(this.readBtn, "click", () => this.handleReadClick());
 
@@ -381,7 +391,10 @@ export class VoicePlayerView extends ItemView {
     this.refreshContext();
   }
 
-  /** Read the current note. Ignored while a synthesis is already running. */
+  /**
+   * Regenerate: force a fresh synthesis of the current note. Ignored while a
+   * synthesis is already running.
+   */
   private handleReadClick(): void {
     if (this.provider().isOperationInProgress()) {
       return;
@@ -852,7 +865,7 @@ export class VoicePlayerView extends ItemView {
 
     // Loading feedback while a note is being synthesized: grow the bottom bar to
     // the real synthesis progress, spin the play button (like the status bar),
-    // and animate (and disable) the "Read this note" button.
+    // and animate (and disable) the "Regenerate" button.
     const loading = provider.isOperationInProgress();
     this.loadingBarEl.toggleClass("is-visible", loading);
     if (loading) {
@@ -868,7 +881,8 @@ export class VoicePlayerView extends ItemView {
     }
     this.readBtn.toggleClass("is-loading", loading);
     this.readBtn.disabled = loading;
-    this.readBtn.setText(loading ? "Reading…" : "Read this note");
+    // Update only the label span so the reload icon is preserved.
+    this.readLabelEl.setText(loading ? "Regenerating…" : "Regenerate");
 
     // Keep the selectors/toggle in sync if settings changed elsewhere.
     if (this.providerSelect.value !== this.plugin.settings.TTS_PROVIDER) {

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -321,15 +321,45 @@ export class VoicePlayerView extends ItemView {
     const provider = this.provider();
     if (provider.isPlaying()) {
       provider.pauseAudio();
-    } else if (this.audio().currentSrc) {
-      // A chapter or previously synthesized note is loaded → resume it.
-      // (Note: audio.src resolves an empty value to the page URL, so we check
-      // currentSrc, which is "" until a real media resource is selected.)
-      void provider.playAudio();
-    } else {
-      // Nothing loaded yet → read the currently open note.
-      void this.plugin.speakText();
+      return;
     }
+
+    // Resume the loaded audio only when it still matches what the player is
+    // showing. (Note: audio.src resolves an empty value to the page URL, so we
+    // check currentSrc, which is "" until a real media resource is selected.)
+    if (this.audio().currentSrc && !this.loadedAudioIsStale()) {
+      void provider.playAudio();
+      return;
+    }
+
+    // Nothing loaded, or the loaded audio was generated for a different note
+    // than the one now open → read the currently open note instead of
+    // replaying the previous one (issue #59).
+    this.currentChapterPath = null;
+    this.highlightCurrentChapter();
+    void this.plugin.speakText();
+  }
+
+  /**
+   * Whether the audio currently loaded in the player no longer matches the
+   * active note. A chapter the user explicitly picked is never treated as
+   * stale; synthesized note audio is stale once the active note differs from
+   * the note it was generated for, so pressing play reads the new note rather
+   * than resuming the previously rendered one.
+   */
+  private loadedAudioIsStale(): boolean {
+    // An explicitly selected chapter keeps control of the play button.
+    if (this.currentChapterPath) {
+      return false;
+    }
+    const active = this.app.workspace.getActiveFile();
+    // No readable note to compare against → keep the current audio.
+    if (!active || active.extension !== "md") {
+      return false;
+    }
+    // Synthesized audio is fresh only while it belongs to the active note;
+    // getLastGeneratedAudio returns null once the cached note path differs.
+    return this.provider().getLastGeneratedAudio(active.path) === null;
   }
 
   /**
@@ -356,6 +386,10 @@ export class VoicePlayerView extends ItemView {
     if (this.provider().isOperationInProgress()) {
       return;
     }
+    // Reading the note replaces any loaded chapter as the active audio, so
+    // drop the chapter selection to keep the highlight and play button honest.
+    this.currentChapterPath = null;
+    this.highlightCurrentChapter();
     void this.plugin.speakText();
   }
 

--- a/styles.css
+++ b/styles.css
@@ -629,7 +629,16 @@
 }
 
 .voice-player-read {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   cursor: pointer;
+}
+
+.voice-player-read .svg-icon {
+  width: 16px;
+  height: 16px;
 }
 
 .voice-player-download {
@@ -871,7 +880,7 @@
   margin-top: 0;
 }
 
-/* "Read this note" loading animation */
+/* "Regenerate" loading animation */
 .voice-player-read.is-loading {
   opacity: 0.85;
   cursor: default;


### PR DESCRIPTION
## Summary

When you select a note in the editor, the player title updates to that note — so pressing the transport **play** button intuitively should read it. Instead, the button resumed whatever audio was still loaded, so after reading note A and then selecting note B, play replayed A's previously rendered audio rather than reading B.

This PR fixes that, and follows up with two related improvements:

- **Renames the "Read this note" button to "Regenerate"** (with a reload icon). Now that play reads the active note on its own, this button's distinct job is to force a fresh synthesis — the old label no longer described that.
- **Adds a project PR template** (`.github/pull_request_template.md`) so future PRs follow a consistent structure automatically.

Closes #59

## Type of change

- [x] fix — bug fix (patch)
- [x] refactor — rename player button + reload icon (no behaviour change to synthesis)
- [x] chore — add PR template
- [ ] feat — new feature (minor)
- [ ] BREAKING CHANGE

## Changes

`src/ui/VoicePlayerView.ts`:

- **`togglePlay`** now resumes loaded audio only when it still matches what the player shows:
  - an explicitly selected **chapter** (unchanged — still resumes), **or**
  - synthesized audio whose cached note path equals the active note (via `getLastGeneratedAudio(active.path)`).
  - Otherwise the loaded audio is stale, so it clears the chapter selection and reads the now-active note.
- Added a small `loadedAudioIsStale()` helper encapsulating that decision.
- **`handleReadClick`** drops a stale chapter selection so the chapter highlight and the play button stay consistent after reading a note.
- Renamed the **"Read this note"** button to **"Regenerate"** with a `refresh-cw` reload icon. The button is split into a persistent icon + a label span so the loading state ("Regenerating…") no longer wipes the icon.

`styles.css`:

- Lay the Regenerate button out as icon + label, consistent with the icon controls beside it.

`README.md`:

- Reword the player section to distinguish **play** (listen / resume) from **Regenerate** (fresh synthesis).

`.github/pull_request_template.md`:

- New PR template with Conventional Commits change types, provider/platform impact checklists, a test-steps section, and a build/lint/test checklist mirroring the feature CI workflow.

The player fix is intentionally targeted: the chapter / audiobook playback flow (a headline feature) is left untouched — only stale "previously rendered note" audio is replaced with a read of the active note.

## Button behaviour after this PR

| Button | Action | Cost |
| --- | --- | --- |
| ▶️ Play | Read the active note, or resume its already-loaded audio | Free on resume |
| ↻ Regenerate | Force a fresh synthesis of the active note from scratch | New provider call |

## Provider impact

- [x] None — the fix is in the shared player and applies to all providers identically

## Platform impact

- [x] Desktop
- [x] Mobile (iOS / Android)

## How to test

1. Open note A and read it in the player.
2. Select note B in the editor — the player title shows B.
3. Press play → **before:** A is replayed; **after:** B is read.
4. Press **Regenerate** → a fresh synthesis runs even if audio already exists.
5. Regression checks: pause/resume of the active note still resumes; clicking a chapter still resumes that chapter.

## Checklist

- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm run lint:check` passes
- [x] `npm test` passes (120/120)
- [ ] Added/updated tests where it makes sense (player view is not currently unit-tested; logic verified manually)
- [x] Updated docs (README player section reworded)
- [x] PR title follows Conventional Commits (`fix(player): …`)
- [x] No secrets/credentials committed

## Screenshots / recordings

Original report (issue #59) includes a video of the wrong-note playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)