### PR TITLE
feat(audio): save MP3s to a custom folder with tap/hold picker (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ On mobile, the same player opens as a full-screen pane, optimized for touch:
   ![voice download](./assets/voice-download.png)
 
 - Prefer a hands-off workflow? Enable **Auto-Save Audio to Note** in settings to save and embed the MP3 automatically after every successful playback — no manual click. Off by default.
+- **Choose where audio is saved** — keep MP3s next to the note (default) or send them to a custom folder. Set **Audio save location → Custom folder** in settings, then **tap** the save button to use your last folder or **hold it** (desktop: or right-click) to pick another. **Star** favorites in the picker for one-tap saving, and type to create a new folder on the spot.
 - Cached audio prevents repeat synthesis costs until your note content changes.
 
 ### Precision Playback Controls
@@ -122,19 +123,20 @@ Everything is configured in one place: **Settings → Voice**. Pick a provider, 
 
 ![Voice settings](./assets/settings.png)
 
-| Setting                               | What it does                                                                                                                                           |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Speech Provider**                   | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI**. The credential fields below adapt to your choice. |
-| **Voice**                             | Pick the voice, gender, and language used for playback.                                                                                                |
-| **Tempo**                             | Set your preferred reading speed (0.5× to 1.9×, default 1.0×).                                                                                         |
-| **Rewind interval**                   | How many seconds the rewind control jumps back (1–60s, default 3s).                                                                                    |
-| **Fast-forward interval**             | How many seconds the fast-forward control jumps ahead (1–60s, default 3s).                                                                             |
-| **Spell Out Acronyms**                | Read uppercase words letter by letter (AWS Polly). Off by default.                                                                                     |
-| **Read Code Blocks**                  | Read fenced code blocks aloud instead of skipping them. Off by default.                                                                                |
-| **Skip Website URLs**                 | Remove URLs from spoken output while keeping link labels. Off by default.                                                                              |
-| **Auto-Save Audio to Note**           | Automatically save and embed the MP3 after each playback. Off by default.                                                                              |
-| **Folder Picker Follows Active Note** | Player's folder picker auto-switches to the folder of the note you're viewing. On by default; turn off to keep your chosen folder.                     |
-| **Test Credentials**                  | Validate your provider keys; on success it reports how many voices are available.                                                                      |
+| Setting                               | What it does                                                                                                                                                                                             |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Speech Provider**                   | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI**. The credential fields below adapt to your choice.                                                   |
+| **Voice**                             | Pick the voice, gender, and language used for playback.                                                                                                                                                  |
+| **Tempo**                             | Set your preferred reading speed (0.5× to 1.9×, default 1.0×).                                                                                                                                           |
+| **Rewind interval**                   | How many seconds the rewind control jumps back (1–60s, default 3s).                                                                                                                                      |
+| **Fast-forward interval**             | How many seconds the fast-forward control jumps ahead (1–60s, default 3s).                                                                                                                               |
+| **Spell Out Acronyms**                | Read uppercase words letter by letter (AWS Polly). Off by default.                                                                                                                                       |
+| **Read Code Blocks**                  | Read fenced code blocks aloud instead of skipping them. Off by default.                                                                                                                                  |
+| **Skip Website URLs**                 | Remove URLs from spoken output while keeping link labels. Off by default.                                                                                                                                |
+| **Auto-Save Audio to Note**           | Automatically save and embed the MP3 after each playback. Off by default.                                                                                                                                |
+| **Audio save location**               | Save MP3s next to the note (default) or in a custom folder chosen via a quick folder picker with favorites. Tap the save button for your last folder; hold it (desktop: or right-click) to pick another. |
+| **Folder Picker Follows Active Note** | Player's folder picker auto-switches to the folder of the note you're viewing. On by default; turn off to keep your chosen folder.                                                                       |
+| **Test Credentials**                  | Validate your provider keys; on success it reports how many voices are available.                                                                                                                        |
 
 ## Keyboard Shortcuts
 

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -6,6 +6,7 @@ import {
   OPENAI_MODELS,
   MIN_SKIP_SECONDS,
   MAX_SKIP_SECONDS,
+  type AudioSaveMode,
 } from "./VoiceSettings";
 import { createSpeechProvider } from "../service/SpeechProviderFactory";
 
@@ -70,6 +71,21 @@ export class VoiceSettingTab extends PluginSettingTab {
     });
     rightIndicator.textContent = "faster +";
     rightIndicator.title = "Move right to increase speed (faster playback)";
+  }
+
+  /**
+   * Platform-aware description for the "Audio save location" setting, so the
+   * tap/hold gesture is explained with the right wording for desktop vs mobile.
+   */
+  private audioSaveLocationDesc(): string {
+    const gesture = this.plugin.isMobile()
+      ? "touch & hold the save button to pick another"
+      : "hold the save button (or right-click) to pick another";
+    return (
+      "Where saved MP3s go. With “Custom folder”, a tap on the save button " +
+      `stores to your last folder — ${gesture}. Star folders in the picker ` +
+      "for one-tap access. Defaults to saving next to the note."
+    );
   }
 
   display(): void {
@@ -281,6 +297,20 @@ export class VoiceSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           }),
       );
+
+    new Setting(containerEl)
+      .setName("Audio save location")
+      .setDesc(this.audioSaveLocationDesc())
+      .addDropdown((dropdown) => {
+        dropdown
+          .addOption("note", "Next to note")
+          .addOption("custom", "Custom folder")
+          .setValue(this.plugin.settings.audioSaveMode)
+          .onChange(async (value) => {
+            this.plugin.settings.audioSaveMode = value as AudioSaveMode;
+            await this.plugin.saveSettings();
+          });
+      });
 
     new Setting(containerEl)
       .setName("Folder Picker Follows Active Note")

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -8,6 +8,15 @@ export type TtsProvider =
   | "azure"
   | "openai";
 
+/**
+ * Where saved MP3s are written.
+ * - "note": next to the active note (the original, default behaviour).
+ * - "custom": into a folder chosen via the folder picker; a tap on the save
+ *   button reuses the last folder, while holding it (or right-click) re-opens
+ *   the picker.
+ */
+export type AudioSaveMode = "note" | "custom";
+
 export interface VoiceSettings {
   // Active text-to-speech provider
   TTS_PROVIDER: TtsProvider;
@@ -50,6 +59,17 @@ export interface VoiceSettings {
   // Player: when true, the player's folder picker follows the active note's
   // folder; when false the chosen folder stays put across note switches.
   folderSelectorFollowsNote: boolean;
+  // Audio files: where saved MP3s go. "note" (default) keeps the original
+  // behaviour of saving next to the active note; "custom" routes saves to a
+  // folder chosen via the folder picker.
+  audioSaveMode: AudioSaveMode;
+  // Audio files: folders the user starred in the picker, shown first for
+  // one-tap access. Stored vault-relative ("/" for the vault root).
+  favoriteAudioFolders: string[];
+  // Audio files: the folder used for the most recent custom save. A tap on the
+  // save button reuses it (and auto-save writes here silently) without
+  // re-opening the picker. Empty until the first custom save.
+  lastAudioFolder: string;
   // Internal: tracks the one-time reset of the legacy spellOutAcronyms default
   acronymDefaultMigrated: boolean;
   // Internal: tracks the one-time placement of the player in the right sidebar
@@ -340,6 +360,9 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   rewindSeconds: DEFAULT_SKIP_SECONDS,
   forwardSeconds: DEFAULT_SKIP_SECONDS,
   folderSelectorFollowsNote: true,
+  audioSaveMode: "note",
+  favoriteAudioFolders: [],
+  lastAudioFolder: "",
   acronymDefaultMigrated: false,
   playerPanePlaced: false,
   lastWhatsNewVersion: "",

--- a/src/ui/FolderPickerModal.ts
+++ b/src/ui/FolderPickerModal.ts
@@ -1,0 +1,147 @@
+import { App, SuggestModal, TFolder, setIcon } from "obsidian";
+import type { Voice } from "../utils/VoicePlugin";
+import { normalizeFolderPath } from "../utils/chapters";
+import {
+  isFavoriteFolder,
+  orderFoldersForPicker,
+  toggleFavorite,
+} from "../utils/audioFolders";
+
+/** A pickable vault folder, or the "create a new folder" affordance. */
+type FolderSuggestion =
+  | { kind: "folder"; path: string; isFavorite: boolean }
+  | { kind: "create"; path: string };
+
+/**
+ * Quick folder picker for the custom audio-folder feature (issue #57).
+ *
+ * Lists every vault folder with fuzzy-ish search, pins the user's starred
+ * folders to the top, lets them star/unstar inline, and offers to create a
+ * folder that does not exist yet. Resolves to the chosen folder path, or null
+ * if the user dismisses the modal.
+ */
+export class FolderPickerModal extends SuggestModal<FolderSuggestion> {
+  private plugin: Voice;
+  private allFolders: string[];
+  private resolve: (value: string | null) => void = () => {};
+  private chosen = false;
+
+  private constructor(app: App, plugin: Voice) {
+    super(app);
+    this.plugin = plugin;
+    this.allFolders = app.vault
+      .getAllLoadedFiles()
+      .filter((f): f is TFolder => f instanceof TFolder)
+      .map((f) => normalizeFolderPath(f.path));
+
+    this.setPlaceholder("Search folders to save audio…");
+    this.setInstructions([
+      { command: "↵", purpose: "save here" },
+      { command: "click ★", purpose: "favorite" },
+      { command: "esc", purpose: "cancel" },
+    ]);
+  }
+
+  /**
+   * Open the picker and resolve with the chosen folder path, or null if the
+   * user cancels.
+   */
+  static open(app: App, plugin: Voice): Promise<string | null> {
+    const modal = new FolderPickerModal(app, plugin);
+    return new Promise((resolve) => {
+      modal.resolve = resolve;
+      modal.open();
+    });
+  }
+
+  getSuggestions(query: string): FolderSuggestion[] {
+    const favorites = this.plugin.settings.favoriteAudioFolders;
+    const ordered = orderFoldersForPicker(this.allFolders, favorites);
+    const q = query.trim().toLowerCase();
+
+    const matches = (
+      q === ""
+        ? ordered
+        : ordered.filter((f) => f.path.toLowerCase().includes(q))
+    ).map(
+      (f): FolderSuggestion => ({
+        kind: "folder",
+        path: f.path,
+        isFavorite: f.isFavorite,
+      }),
+    );
+
+    // Offer to create a folder when the query does not name an existing one.
+    const normalizedQuery = normalizeFolderPath(query.trim());
+    if (q !== "" && !this.allFolders.some((p) => p.toLowerCase() === q)) {
+      matches.push({ kind: "create", path: normalizedQuery });
+    }
+
+    return matches;
+  }
+
+  renderSuggestion(item: FolderSuggestion, el: HTMLElement): void {
+    el.addClass("voice-folder-suggestion");
+
+    if (item.kind === "create") {
+      const icon = el.createSpan({ cls: "voice-folder-suggestion-icon" });
+      setIcon(icon, "folder-plus");
+      el.createSpan({
+        cls: "voice-folder-suggestion-name",
+        text: `Create folder “${item.path}”`,
+      });
+      return;
+    }
+
+    const icon = el.createSpan({ cls: "voice-folder-suggestion-icon" });
+    setIcon(icon, item.path === "/" ? "home" : "folder");
+    el.createSpan({
+      cls: "voice-folder-suggestion-name",
+      text: item.path === "/" ? "Vault root" : item.path,
+    });
+
+    // Inline star toggle. stopPropagation keeps a star click from also choosing
+    // the folder (which would close the modal).
+    const star = el.createSpan({ cls: "voice-folder-suggestion-star" });
+    setIcon(star, item.isFavorite ? "star" : "star-off");
+    star.toggleClass("is-favorite", item.isFavorite);
+    star.setAttribute(
+      "aria-label",
+      item.isFavorite ? "Remove from favorites" : "Add to favorites",
+    );
+    star.addEventListener("click", (evt) => {
+      evt.stopPropagation();
+      evt.preventDefault();
+      void this.toggleFavoriteFor(item.path);
+    });
+  }
+
+  onChooseSuggestion(item: FolderSuggestion): void {
+    this.chosen = true;
+    this.resolve(item.path);
+  }
+
+  onClose(): void {
+    super.onClose();
+    // If the modal closed without a choice (esc / click-away), report a cancel.
+    if (!this.chosen) {
+      this.resolve(null);
+    }
+  }
+
+  /** Star/unstar a folder and re-render the list in place. */
+  private async toggleFavoriteFor(path: string): Promise<void> {
+    this.plugin.settings.favoriteAudioFolders = toggleFavorite(
+      this.plugin.settings.favoriteAudioFolders,
+      path,
+    );
+    await this.plugin.saveSettings();
+    // Re-run getSuggestions so the star icon and ordering refresh immediately.
+    this.inputEl.dispatchEvent(new Event("input"));
+  }
+
+  /** Whether a folder is currently a favorite (used by callers/tests). */
+  isFavorite(path: string): boolean {
+    return isFavoriteFolder(this.plugin.settings.favoriteAudioFolders, path);
+  }
+}

--- a/src/utils/AudioFileManager.ts
+++ b/src/utils/AudioFileManager.ts
@@ -17,11 +17,17 @@ export class AudioFileManager {
   }
 
   /**
-   * Save audio blob as MP3 file in the same directory as the active file
+   * Save audio blob as an MP3 file.
    * @param audioBlob - The audio data to save
+   * @param targetFolder - Vault-relative folder to save into ("/" or "" = vault
+   *   root). When omitted, the MP3 is saved next to the active note, preserving
+   *   the original behaviour.
    * @returns The created/modified TFile or null on error
    */
-  async saveAudioFile(audioBlob: Blob): Promise<TFile | null> {
+  async saveAudioFile(
+    audioBlob: Blob,
+    targetFolder?: string,
+  ): Promise<TFile | null> {
     try {
       const activeFile = this.app.workspace.getActiveFile();
       if (!activeFile) {
@@ -31,11 +37,18 @@ export class AudioFileManager {
 
       // Construct MP3 filename based on active file
       const fileName = activeFile.basename;
-      const fileDir = activeFile.parent?.path || "";
+      const fileDir = this.resolveSaveDir(
+        targetFolder,
+        activeFile.parent?.path || "",
+      );
       const audioFileName = `${fileName}.mp3`;
       const audioFilePath = normalizePath(
         fileDir ? `${fileDir}/${audioFileName}` : audioFileName,
       );
+
+      // Make sure the destination folder exists before writing into it
+      // (custom folders may not have been created yet).
+      await this.ensureFolderExists(fileDir);
 
       // Convert Blob to ArrayBuffer
       const arrayBuffer = await audioBlob.arrayBuffer();
@@ -64,6 +77,38 @@ export class AudioFileManager {
       new Notice(`Error saving audio file: ${error.message}`);
       return null;
     }
+  }
+
+  /**
+   * Resolve the destination folder for a save.
+   * - `undefined` target → next to the active note (original behaviour).
+   * - "/" or "" target → the vault root.
+   * - otherwise → the given vault-relative folder.
+   */
+  private resolveSaveDir(
+    targetFolder: string | undefined,
+    noteFolder: string,
+  ): string {
+    if (targetFolder === undefined) {
+      return noteFolder;
+    }
+    const trimmed = targetFolder.trim();
+    return trimmed === "/" ? "" : trimmed;
+  }
+
+  /**
+   * Create the destination folder (and any missing parents) if it does not
+   * already exist. No-op for the vault root.
+   */
+  private async ensureFolderExists(folderPath: string): Promise<void> {
+    if (!folderPath) {
+      return;
+    }
+    const existing = this.app.vault.getAbstractFileByPath(folderPath);
+    if (existing) {
+      return;
+    }
+    await this.app.vault.createFolder(folderPath);
   }
 
   /**
@@ -134,10 +179,14 @@ export class AudioFileManager {
    * @param audioBlob - The audio data to save
    * @param embed - Whether to also insert the `![[file.mp3]]` embed in the
    *   note. Defaults to true to preserve the legacy save-and-embed behaviour.
+   * @param targetFolder - Vault-relative folder to save into. When omitted, the
+   *   MP3 is saved next to the active note. The embed still resolves by file
+   *   name, so it works regardless of the folder.
    */
   async downloadAndEmbed(
     audioBlob: Blob,
     embed: boolean = true,
+    targetFolder?: string,
   ): Promise<void> {
     try {
       const activeFile = this.app.workspace.getActiveFile();
@@ -150,7 +199,7 @@ export class AudioFileManager {
       const audioFileName = `${fileName}.mp3`;
 
       // Save the audio file
-      const savedFile = await this.saveAudioFile(audioBlob);
+      const savedFile = await this.saveAudioFile(audioBlob, targetFolder);
       if (!savedFile) {
         return; // Error already shown in saveAudioFile
       }

--- a/src/utils/IconEventHandler.ts
+++ b/src/utils/IconEventHandler.ts
@@ -3,6 +3,9 @@ import { Voice } from "./VoicePlugin";
 import type { SpeechProvider } from "../service/SpeechProvider";
 import { MobileControlBar } from "./MobileControlBar";
 import { AudioFileManager } from "./AudioFileManager";
+import { FolderPickerModal } from "../ui/FolderPickerModal";
+import { resolveSaveFolder } from "./audioFolders";
+import { attachPressGesture } from "./pressGesture";
 
 export class IconEventHandler {
   private pollyService: SpeechProvider;
@@ -233,15 +236,18 @@ export class IconEventHandler {
       `Fast-forward ${this.voice.settings.forwardSeconds} seconds`,
     );
 
-    // Download MP3 (initially hidden)
+    // Download MP3 (initially hidden). The plain click is handled by the press
+    // gesture below (tap = save, hold/right-click = choose folder), so no
+    // onClick is wired here.
     this.downloadIconEl = this.createStatusBarIcon(
       "download",
       "download-audio",
-      () => void this.handleDownloadAudio(),
+      () => {},
       false,
       "Download audio as MP3",
     );
     this.downloadIconEl.addClass("voice-hidden"); // Initially hidden
+    this.attachSaveGesture(this.downloadIconEl);
 
     // Add separator after all voice controls to separate from other plugins
     this.addVoiceControlsSeparator();
@@ -561,6 +567,9 @@ export class IconEventHandler {
    * Update download button visibility based on whether cached audio exists for current file
    */
   private updateDownloadButtonVisibility(): void {
+    // Keep the tooltip in sync with the current save mode / last folder.
+    this.updateSaveTooltip();
+
     const activeFile = this.plugin.app.workspace.getActiveFile();
     if (!activeFile) {
       this.hideDownloadButton();
@@ -598,17 +607,30 @@ export class IconEventHandler {
       return;
     }
 
+    // Auto-save never prompts: it writes to the resolved folder silently
+    // (custom mode → last used folder, falling back to the note's folder).
+    const folder = resolveSaveFolder(
+      this.voice.settings.audioSaveMode,
+      this.voice.settings.lastAudioFolder,
+      activeFile.parent?.path || "",
+    );
     await this.audioFileManager.downloadAndEmbed(
       audioBlob,
       this.voice.settings.autoEmbedAudio,
+      folder,
     );
   }
 
   /**
    * Handle download audio button click (also exposed as a command).
-   * Retrieves cached audio blob and saves it as MP3 file.
+   * Retrieves cached audio blob and saves it as an MP3 file in the resolved
+   * folder.
+   * @param options.forcePicker - Open the folder picker even when a last folder
+   *   exists (the "hold"/right-click gesture). Ignored in "next to note" mode.
    */
-  public async handleDownloadAudio(): Promise<void> {
+  public async handleDownloadAudio(options?: {
+    forcePicker?: boolean;
+  }): Promise<void> {
     try {
       // Get current file path for validation
       const activeFile = this.plugin.app.workspace.getActiveFile();
@@ -629,14 +651,96 @@ export class IconEventHandler {
         return;
       }
 
+      const folder = await this.resolveManualSaveFolder(
+        activeFile.parent?.path || "",
+        options?.forcePicker ?? false,
+      );
+      if (folder === null) {
+        return; // User dismissed the folder picker.
+      }
+
       // Use AudioFileManager to save and (optionally) embed
       await this.audioFileManager.downloadAndEmbed(
         audioBlob,
         this.voice.settings.autoEmbedAudio,
+        folder,
       );
     } catch (error) {
       console.error("Error downloading audio:", error);
       new Notice(`Failed to download audio: ${error.message}`);
     }
+  }
+
+  /**
+   * Resolve the destination folder for a manual save. In "next to note" mode
+   * this is always the note's folder. In "custom" mode a tap reuses the last
+   * folder (opening the picker only the first time), while a hold/right-click
+   * forces the picker. Returns null when the user dismisses the picker.
+   */
+  private async resolveManualSaveFolder(
+    noteFolder: string,
+    forcePicker: boolean,
+  ): Promise<string | null> {
+    const settings = this.voice.settings;
+    if (settings.audioSaveMode === "note") {
+      return noteFolder;
+    }
+
+    const needsPicker = forcePicker || settings.lastAudioFolder.trim() === "";
+    if (needsPicker) {
+      const chosen = await FolderPickerModal.open(this.plugin.app, this.voice);
+      if (chosen === null) {
+        return null;
+      }
+      settings.lastAudioFolder = chosen;
+      await this.voice.saveSettings();
+      this.updateSaveTooltip();
+      return chosen;
+    }
+
+    return resolveSaveFolder(
+      settings.audioSaveMode,
+      settings.lastAudioFolder,
+      noteFolder,
+    );
+  }
+
+  /**
+   * Wire the tap-vs-hold gesture onto a save button: tap saves, hold (or
+   * right-click) opens the folder picker. Holding is only active in custom
+   * mode.
+   */
+  private attachSaveGesture(el: HTMLElement): void {
+    attachPressGesture(el, {
+      onTap: () => void this.handleDownloadAudio(),
+      onHold: () => void this.handleDownloadAudio({ forcePicker: true }),
+      isHoldEnabled: () => this.voice.settings.audioSaveMode === "custom",
+    });
+  }
+
+  /**
+   * Refresh the download button's tooltip to reflect the current save mode and
+   * target folder, including a platform-appropriate hint about the hold gesture.
+   */
+  private updateSaveTooltip(): void {
+    if (!this.downloadIconEl) {
+      return;
+    }
+    this.downloadIconEl.title = this.saveTooltip();
+  }
+
+  private saveTooltip(): string {
+    const settings = this.voice.settings;
+    if (settings.audioSaveMode === "note") {
+      return "Download audio as MP3";
+    }
+    const folder =
+      settings.lastAudioFolder.trim() === ""
+        ? "a folder you pick"
+        : settings.lastAudioFolder;
+    const hint = this.voice.isMobile()
+      ? "touch & hold to choose folder"
+      : "hold or right-click to choose folder";
+    return `Save to ${folder} — ${hint}`;
   }
 }

--- a/src/utils/MobileControlBar.ts
+++ b/src/utils/MobileControlBar.ts
@@ -1,8 +1,8 @@
-import { App, setIcon, Notice, Menu } from "obsidian";
+import { App, setIcon, Menu } from "obsidian";
 import { Voice } from "./VoicePlugin";
 import type { SpeechProvider } from "../service/SpeechProvider";
-import { AudioFileManager } from "./AudioFileManager";
 import { VIEW_TYPE_VOICE_PLAYER } from "../ui/VoicePlayerView";
+import { attachPressGesture } from "./pressGesture";
 
 export class MobileControlBar {
   private app: App;
@@ -16,13 +16,11 @@ export class MobileControlBar {
   private progressBarContainer: HTMLElement | null = null;
   private progressBar: HTMLElement | null = null;
   private isErrorState: boolean = false;
-  private audioFileManager: AudioFileManager;
 
   constructor(app: App, plugin: Voice, pollyService: SpeechProvider) {
     this.app = app;
     this.plugin = plugin;
     this.pollyService = pollyService;
-    this.audioFileManager = new AudioFileManager(app);
     this.createOverlayBar();
     this.initializeEventListeners();
 
@@ -85,14 +83,24 @@ export class MobileControlBar {
       },
     );
 
-    // Download MP3 button (initially hidden)
+    // Download MP3 button (initially hidden). Tap saves; hold (custom mode)
+    // opens the folder picker. Both go through the shared handler so desktop
+    // and mobile behave identically. The plain click is handled by the gesture.
     this.downloadIconEl = this.createControlButton(
       controlsWrapper,
       "download",
       "Download Audio",
-      () => void this.handleDownloadAudio(),
+      () => {},
     );
     this.downloadIconEl.addClass("voice-hidden"); // Initially hidden
+    attachPressGesture(this.downloadIconEl, {
+      onTap: () => void this.plugin.iconEventHandler.handleDownloadAudio(),
+      onHold: () =>
+        void this.plugin.iconEventHandler.handleDownloadAudio({
+          forcePicker: true,
+        }),
+      isHoldEnabled: () => this.plugin.settings.audioSaveMode === "custom",
+    });
 
     // Rewind button
     this.createControlButton(
@@ -419,41 +427,6 @@ export class MobileControlBar {
       this.showDownloadButton();
     } else {
       this.hideDownloadButton();
-    }
-  }
-
-  /**
-   * Handle download audio button click
-   */
-  private async handleDownloadAudio(): Promise<void> {
-    try {
-      // Get current file path for validation
-      const activeFile = this.app.workspace.getActiveFile();
-      if (!activeFile) {
-        new Notice("No active file found");
-        return;
-      }
-
-      // Get the cached audio blob from Polly service with file path validation
-      const audioBlob = this.pollyService.getLastGeneratedAudio(
-        activeFile.path,
-      );
-
-      if (!audioBlob) {
-        new Notice(
-          "No audio available for this file. Please generate audio first.",
-        );
-        return;
-      }
-
-      // Use AudioFileManager to save and (optionally) embed
-      await this.audioFileManager.downloadAndEmbed(
-        audioBlob,
-        this.plugin.settings.autoEmbedAudio,
-      );
-    } catch (error) {
-      console.error("Error downloading audio:", error);
-      new Notice(`Failed to download audio: ${error.message}`);
     }
   }
 

--- a/src/utils/audioFolders.ts
+++ b/src/utils/audioFolders.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure helpers for the custom audio-folder feature (issue #57).
+ *
+ * Kept free of Obsidian APIs so the folder-resolution and favorites logic can
+ * be unit-tested in isolation; the Obsidian-facing pieces (the picker modal and
+ * the save orchestration) build on top of these.
+ */
+
+import type { AudioSaveMode } from "../settings/VoiceSettings";
+import { normalizeFolderPath } from "./chapters";
+
+/**
+ * Decide which folder a non-interactive save (a tap on the save button, or a
+ * silent auto-save) should write to.
+ *
+ * - "note" mode always saves next to the active note.
+ * - "custom" mode reuses the last folder the user picked; until they have
+ *   picked one, it falls back to the note's folder so a save never fails.
+ *
+ * @param mode          The configured audio save mode.
+ * @param lastAudioFolder The most recently used custom folder (may be empty).
+ * @param activeFolder  The active note's folder (vault-relative; "/" = root).
+ */
+export function resolveSaveFolder(
+  mode: AudioSaveMode,
+  lastAudioFolder: string,
+  activeFolder: string,
+): string {
+  if (mode === "custom" && lastAudioFolder.trim() !== "") {
+    return normalizeFolderPath(lastAudioFolder);
+  }
+  return normalizeFolderPath(activeFolder);
+}
+
+/**
+ * Whether a folder is in the favorites list (path-normalized comparison).
+ */
+export function isFavoriteFolder(favorites: string[], path: string): boolean {
+  const target = normalizeFolderPath(path);
+  return favorites.some((f) => normalizeFolderPath(f) === target);
+}
+
+/**
+ * Add or remove a folder from the favorites list, returning a new array.
+ * Comparison is path-normalized so "/" and "" never produce duplicates.
+ */
+export function toggleFavorite(favorites: string[], path: string): string[] {
+  const target = normalizeFolderPath(path);
+  if (isFavoriteFolder(favorites, path)) {
+    return favorites.filter((f) => normalizeFolderPath(f) !== target);
+  }
+  return [...favorites, target];
+}
+
+export interface PickerFolder {
+  /** Vault-relative folder path ("/" for the vault root). */
+  path: string;
+  /** Whether the folder is starred. */
+  isFavorite: boolean;
+}
+
+/**
+ * Order folders for the picker: favorites first (in their saved order), then
+ * the remaining folders sorted naturally by path. Used when the search box is
+ * empty so the user's starred folders are always within reach.
+ *
+ * @param allFolders All vault folder paths.
+ * @param favorites  The starred folder paths.
+ */
+export function orderFoldersForPicker(
+  allFolders: string[],
+  favorites: string[],
+): PickerFolder[] {
+  const normalizedAll = [...new Set(allFolders.map(normalizeFolderPath))];
+  const favSet = new Set(favorites.map(normalizeFolderPath));
+
+  const favs = favorites
+    .map(normalizeFolderPath)
+    .filter((f) => normalizedAll.includes(f))
+    .map((path) => ({ path, isFavorite: true }));
+
+  const rest = normalizedAll
+    .filter((p) => !favSet.has(p))
+    .sort((a, b) =>
+      a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }),
+    )
+    .map((path) => ({ path, isFavorite: false }));
+
+  return [...favs, ...rest];
+}

--- a/src/utils/pressGesture.ts
+++ b/src/utils/pressGesture.ts
@@ -1,0 +1,161 @@
+/**
+ * Tap-vs-hold press gesture for the save buttons (issue #57).
+ *
+ * A short tap fires `onTap`; pressing and holding past `holdMs` fires `onHold`
+ * instead (and the following click is suppressed so only one action runs).
+ * While holding, a CSS variable `--press` (0→1) and a `voice-pressing` class are
+ * applied to the element so a fill/ring can animate. Works with mouse and
+ * touch via Pointer Events.
+ *
+ * Hold detection is gated by `isHoldEnabled` — when it returns false (e.g. the
+ * "next to note" save mode), the element behaves as a plain tap target with no
+ * hold affordance.
+ */
+export interface PressGestureHandlers {
+  onTap: () => void;
+  onHold: () => void;
+  /** When false, the hold path is disabled and only taps fire. Default: on. */
+  isHoldEnabled?: () => boolean;
+  /** Milliseconds to hold before `onHold` fires. Default 450. */
+  holdMs?: number;
+}
+
+const MOVE_CANCEL_THRESHOLD_PX = 10;
+
+/**
+ * Attach the gesture to an element. Returns a cleanup function that removes the
+ * listeners and any lingering visual state.
+ */
+export function attachPressGesture(
+  el: HTMLElement,
+  handlers: PressGestureHandlers,
+): () => void {
+  const holdMs = handlers.holdMs ?? 450;
+  let pointerId: number | null = null;
+  let startX = 0;
+  let startY = 0;
+  let holdFired = false;
+  let moved = false;
+  let rafId: number | null = null;
+  let startTime = 0;
+
+  const holdEnabled = () =>
+    handlers.isHoldEnabled ? handlers.isHoldEnabled() : true;
+
+  const clearVisual = () => {
+    if (rafId !== null) {
+      window.cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    el.removeClass("voice-pressing");
+    el.style.removeProperty("--press");
+  };
+
+  const tick = () => {
+    const fraction = Math.min(1, (performance.now() - startTime) / holdMs);
+    el.setCssProps({ "--press": `${fraction}` });
+    if (fraction >= 1) {
+      holdFired = true;
+      clearVisual();
+      handlers.onHold();
+      return;
+    }
+    rafId = window.requestAnimationFrame(tick);
+  };
+
+  const reset = () => {
+    pointerId = null;
+    clearVisual();
+  };
+
+  const onPointerDown = (evt: PointerEvent) => {
+    // Primary button / touch only.
+    if (evt.button !== 0 || pointerId !== null) {
+      return;
+    }
+    pointerId = evt.pointerId;
+    startX = evt.clientX;
+    startY = evt.clientY;
+    holdFired = false;
+    moved = false;
+
+    if (holdEnabled()) {
+      try {
+        el.setPointerCapture(evt.pointerId);
+      } catch {
+        // Capture is best-effort; ignore if unsupported.
+      }
+      el.addClass("voice-pressing");
+      startTime = performance.now();
+      el.setCssProps({ "--press": "0" });
+      rafId = window.requestAnimationFrame(tick);
+    }
+  };
+
+  const onPointerMove = (evt: PointerEvent) => {
+    if (evt.pointerId !== pointerId) {
+      return;
+    }
+    if (
+      Math.abs(evt.clientX - startX) > MOVE_CANCEL_THRESHOLD_PX ||
+      Math.abs(evt.clientY - startY) > MOVE_CANCEL_THRESHOLD_PX
+    ) {
+      moved = true;
+      clearVisual();
+    }
+  };
+
+  const onPointerUp = (evt: PointerEvent) => {
+    if (evt.pointerId !== pointerId) {
+      return;
+    }
+    clearVisual();
+    if (!holdFired && !moved) {
+      handlers.onTap();
+    }
+    pointerId = null;
+  };
+
+  const onPointerCancel = (evt: PointerEvent) => {
+    if (evt.pointerId !== pointerId) {
+      return;
+    }
+    reset();
+  };
+
+  // Swallow the synthetic click that follows a hold so the action runs once.
+  const onClick = (evt: MouseEvent) => {
+    if (holdFired) {
+      evt.preventDefault();
+      evt.stopPropagation();
+      holdFired = false;
+    }
+  };
+
+  // Right-click is an accessible alternative to hold (desktop).
+  const onContextMenu = (evt: MouseEvent) => {
+    if (!holdEnabled()) {
+      return;
+    }
+    evt.preventDefault();
+    reset();
+    handlers.onHold();
+  };
+
+  el.addEventListener("pointerdown", onPointerDown);
+  el.addEventListener("pointermove", onPointerMove);
+  el.addEventListener("pointerup", onPointerUp);
+  el.addEventListener("pointercancel", onPointerCancel);
+  el.addEventListener("click", onClick);
+  el.addEventListener("contextmenu", onContextMenu);
+
+  return () => {
+    clearVisual();
+    el.removeEventListener("pointerdown", onPointerDown);
+    el.removeEventListener("pointermove", onPointerMove);
+    el.removeEventListener("pointerup", onPointerUp);
+    el.removeEventListener("pointercancel", onPointerCancel);
+    el.removeEventListener("click", onClick);
+    el.removeEventListener("contextmenu", onContextMenu);
+  };
+}

--- a/src/utils/whatsNew.ts
+++ b/src/utils/whatsNew.ts
@@ -20,7 +20,15 @@ export const HERO_IMAGE_URL =
  * (the headline feature many users have not discovered yet), then summarizes
  * everything added since 1.8.0 so long-time users catch up at a glance.
  */
-export const WHATS_NEW = `## 🔊 The Voice player is here
+export const WHATS_NEW = `## 📁 Save audio where you want
+
+Keep your vault tidy — choose a **custom folder** for saved MP3s instead of dropping them next to every note.
+
+- **Set it once** in Settings → Voice → **Audio save location → Custom folder**.
+- **Tap** the save button to store in your last folder; **hold it** (or right-click on desktop) to pick another.
+- **Star** your favorite folders in the picker for one-tap saving — and type to create a new folder on the spot.
+
+## 🔊 The Voice player is here
 
 Voice now has a full **audiobook-style player** — and it lives in the right sidebar (next to Backlinks and Outline) by default, so it is always one click away. If you have not updated in a while, this is the big one.
 

--- a/styles.css
+++ b/styles.css
@@ -920,3 +920,59 @@
   background: var(--interactive-accent);
   transition: width 0.2s ease;
 }
+
+/* Tap-vs-hold save gesture (issue #57): a ring fills around the save button
+   while it is held, signalling that the folder picker is about to open. The
+   --press custom property (0→1) is driven from pressGesture.ts. */
+.voice-pressing {
+  position: relative;
+}
+
+.voice-pressing::after {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--interactive-accent) calc(var(--press, 0) * 360deg),
+    transparent 0deg
+  );
+  -webkit-mask: radial-gradient(closest-side, transparent 68%, #000 70%);
+  mask: radial-gradient(closest-side, transparent 68%, #000 70%);
+  pointer-events: none;
+}
+
+/* Folder picker (custom audio-folder feature) */
+.voice-folder-suggestion {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.voice-folder-suggestion-icon {
+  display: inline-flex;
+  color: var(--text-muted);
+}
+
+.voice-folder-suggestion .svg-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.voice-folder-suggestion-name {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.voice-folder-suggestion-star {
+  display: inline-flex;
+  color: var(--text-faint);
+  cursor: pointer;
+}
+
+.voice-folder-suggestion-star:hover,
+.voice-folder-suggestion-star.is-favorite {
+  color: var(--text-accent);
+}

--- a/tests/audio-folders.unit.test.ts
+++ b/tests/audio-folders.unit.test.ts
@@ -1,0 +1,80 @@
+import {
+  resolveSaveFolder,
+  isFavoriteFolder,
+  toggleFavorite,
+  orderFoldersForPicker,
+} from "../src/utils/audioFolders";
+import { DEFAULT_SETTINGS } from "../src/settings/VoiceSettings";
+
+describe("Unit Tests - Custom Audio Folder", () => {
+  describe("resolveSaveFolder", () => {
+    test("note mode always uses the note's folder", () => {
+      expect(resolveSaveFolder("note", "Media/Audio", "Notes")).toBe("Notes");
+    });
+
+    test("note mode normalizes the vault root to '/'", () => {
+      expect(resolveSaveFolder("note", "", "")).toBe("/");
+    });
+
+    test("custom mode uses the last folder when set", () => {
+      expect(resolveSaveFolder("custom", "Media/Audio", "Notes")).toBe(
+        "Media/Audio",
+      );
+    });
+
+    test("custom mode falls back to the note folder when no last folder", () => {
+      expect(resolveSaveFolder("custom", "", "Notes")).toBe("Notes");
+      expect(resolveSaveFolder("custom", "   ", "Notes")).toBe("Notes");
+    });
+  });
+
+  describe("favorites", () => {
+    test("toggleFavorite adds a folder", () => {
+      expect(toggleFavorite([], "Media/Audio")).toEqual(["Media/Audio"]);
+    });
+
+    test("toggleFavorite removes an existing folder", () => {
+      expect(toggleFavorite(["Media/Audio"], "Media/Audio")).toEqual([]);
+    });
+
+    test("toggleFavorite normalizes the vault root", () => {
+      expect(toggleFavorite([], "")).toEqual(["/"]);
+      expect(toggleFavorite(["/"], "")).toEqual([]);
+    });
+
+    test("isFavoriteFolder matches path-normalized", () => {
+      expect(isFavoriteFolder(["/"], "")).toBe(true);
+      expect(isFavoriteFolder(["Media"], "Media")).toBe(true);
+      expect(isFavoriteFolder(["Media"], "Other")).toBe(false);
+    });
+  });
+
+  describe("orderFoldersForPicker", () => {
+    test("lists favorites first, then the rest sorted naturally", () => {
+      const all = ["b", "a", "Media/Audio", "c"];
+      const favorites = ["Media/Audio", "c"];
+      const result = orderFoldersForPicker(all, favorites);
+      expect(result.map((f) => f.path)).toEqual(["Media/Audio", "c", "a", "b"]);
+      expect(result[0].isFavorite).toBe(true);
+      expect(result[2].isFavorite).toBe(false);
+    });
+
+    test("ignores favorites that no longer exist", () => {
+      const result = orderFoldersForPicker(["a"], ["gone"]);
+      expect(result.map((f) => f.path)).toEqual(["a"]);
+    });
+
+    test("de-duplicates folders", () => {
+      const result = orderFoldersForPicker(["a", "a"], []);
+      expect(result.map((f) => f.path)).toEqual(["a"]);
+    });
+  });
+
+  describe("default settings", () => {
+    test("default to saving next to the note with no favorites", () => {
+      expect(DEFAULT_SETTINGS.audioSaveMode).toBe("note");
+      expect(DEFAULT_SETTINGS.favoriteAudioFolders).toEqual([]);
+      expect(DEFAULT_SETTINGS.lastAudioFolder).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional **custom save location** for generated MP3s, so users can keep audio out of their note folders and avoid visual clutter. The settings stay minimal — a single **Audio save location** choice (Next to note / Custom folder). Everything else happens at save time through a tap-vs-hold gesture and a quick folder picker.

Closes #57

Also largely addresses #58 (duplicate/cluttered renders): a dedicated custom folder removes the need to manually move MP3s out of note folders, which was the root of that report. Not auto-closing #58 since its second half is a discoverability ask — happy to follow up there.

## Type of change

- [x] feat — new feature (minor)
- [ ] fix — bug fix (patch)
- [ ] docs — documentation only
- [ ] refactor / chore — no user-facing change
- [ ] BREAKING CHANGE

## Changes

- **Settings** (`VoiceSettings.ts`, `VoiceSettingTab.ts`): new `audioSaveMode` (`note` | `custom`), `favoriteAudioFolders`, `lastAudioFolder`. One new "Audio save location" dropdown with a **platform-aware** description of the gesture (desktop: hold/right-click; mobile: touch & hold). Default `note` → existing users are unaffected.
- **Folder picker** (`src/ui/FolderPickerModal.ts`): fuzzy search over all vault folders, favorites pinned on top with an inline ★ toggle, and a "Create folder …" option for new folders.
- **Tap-vs-hold gesture** (`src/utils/pressGesture.ts`): reusable Pointer-Events helper. Tap = save to last folder; hold (~450 ms) or right-click = open picker. A fill ring animates while holding (CSS `--press`), and the following click is suppressed so only one action runs. Movement cancels the hold (so scrolling on mobile is safe).
- **Save flow** (`AudioFileManager.ts`, `IconEventHandler.ts`, `MobileControlBar.ts`): `saveAudioFile`/`downloadAndEmbed` accept a target folder and create it (and parents) if missing. A central `resolveSaveFolder` drives all save call sites. Auto-save writes to the resolved folder **silently** (never prompts). The mobile bar now routes its download through the shared handler, removing a duplicate implementation.
- **Helpers** (`src/utils/audioFolders.ts`): pure, unit-tested `resolveSaveFolder`, `toggleFavorite`, `isFavoriteFolder`, `orderFoldersForPicker`.
- **Docs**: new section in the What's New modal and README (feature bullet + settings table row).

Embeds still resolve by file name (`[[note.mp3]]`), so they keep working regardless of which folder the MP3 lives in.

## Provider impact

- [x] None — the feature lives in the shared save/UI layer and is identical across providers

## Platform impact

- [x] Desktop
- [x] Mobile (iOS / Android)

## How to test

1. Settings → Voice → **Audio save location → Custom folder**.
2. Generate audio for a note, then **tap** the save button → first time opens the picker; pick a folder and confirm the MP3 lands there and is embedded.
3. Save again with a **tap** → goes straight to that last folder (no prompt).
4. **Hold** the save button (or right-click on desktop) → picker reopens; **star** a folder and confirm it pins to the top.
5. Type a new folder name → **Create folder …** → confirm it's created and used.
6. Switch back to **Next to note** → saves next to the note as before; holding does nothing special.
7. Enable **Auto-Save** in custom mode → confirm it saves to the last folder silently (no modal).

## Checklist

- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm run lint:check` passes
- [x] `npm test` passes (132/132, +12 new)
- [x] `npm run format:check` passes
- [x] Added/updated tests where it makes sense (pure folder-resolution / favorites / ordering logic)
- [x] Updated docs (README + What's New)
- [x] PR title follows Conventional Commits (`feat(audio): …`)
- [x] No secrets/credentials committed

> Note: the UI gesture (hold ring, touch long-press, picker modal) was verified via unit-tested logic but not run inside a live Obsidian instance — worth a manual smoke test on desktop **and** mobile before release.

## Screenshots / recordings

_Not captured (no live Obsidian instance in CI). Manual verification recommended per the steps above._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyFh958nxJcV1SgxvsUxyh)_