### PR TITLE
feat(azure): full voice catalog grouped by language, plus player & feedback polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,13 @@ jobs:
         with:
           bump_each_commit: false
           tag_prefix: ""
-          major_pattern: "BREAKING CHANGE:"
-          minor_pattern: "feat:"
+          # Patterns are regular expressions (wrapped in /.../). Plain strings
+          # would be matched literally, so a scoped Conventional Commit like
+          # "feat(player): …" would NOT contain the substring "feat:" and would
+          # be missed — bumping only the patch instead of the minor. The regexes
+          # below allow an optional scope "(...)" and the breaking-change "!".
+          major_pattern: "/^[a-z]+(\\([^)]+\\))?!:|BREAKING CHANGE:/"
+          minor_pattern: "/^feat(\\([^)]+\\))?!?:/"
           bump_each_commit_patch_pattern: "fix:|docs:|style:|refactor:|perf:|test:|build:|ci:|chore:"
 
       - name: Verify version does not exist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,12 @@ All providers implement one interface so the rest of the plugin is
 - `SpeechProviderFactory.ts` — `createSpeechProvider(settings)` builds the
   provider chosen in settings and applies rewind/forward prefs.
 - `textChunker.ts` — splits long text for the text-input providers.
+- `voiceCatalog.ts` — **pure** helpers (unit-tested) to map a provider's fetched
+  voice list into `VoiceOption[]` and group it by language for the picker.
+  Azure uses it: "Test Credentials" fetches `/voices/list`, the result is cached
+  in `settings.azureVoiceCatalog`, and `getVoiceOptions()` returns it (the
+  hardcoded `AZURE_VOICES` is the fallback). The player renders the catalog as
+  `<optgroup>`s grouped by language.
 
 `inputFormat` selects which content pipeline feeds the provider:
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ In the Voice player there's also a dedicated **folder button** (📂, next to th
   ![voice picker](./assets/voices.png)
 
 - Switch voices instantly from the player's voice dropdown or the status bar, or use the **Switch to the next speaker.** command to cycle through them hands-free.
+- **Azure: every voice, grouped by language.** Press **Test Credentials** in settings and Voice loads your account's full Azure neural catalog (hundreds of voices), organized by language in the picker — no more being limited to a handful.
 
 ### Fine-Tune What Gets Spoken
 

--- a/src/service/AzureSpeechService.ts
+++ b/src/service/AzureSpeechService.ts
@@ -6,6 +6,7 @@ import {
 } from "../settings/VoiceSettings";
 import { BaseSpeechService } from "./BaseSpeechService";
 import type { CredentialValidationResult } from "./SpeechProvider";
+import { mapAzureVoices } from "./voiceCatalog";
 
 /**
  * Azure AI Speech (Cognitive Services) Text-to-Speech integration.
@@ -30,20 +31,35 @@ export class AzureSpeechService extends BaseSpeechService {
 
   private apiKey: string;
   private region: string;
+  // The full catalog fetched on "Test Credentials" (cached in settings). Falls
+  // back to the curated AZURE_VOICES list until the user has validated.
+  private dynamicVoices: VoiceOption[] | null;
 
-  constructor(apiKey: string, region: string, voice: string, speed?: number) {
+  constructor(
+    apiKey: string,
+    region: string,
+    voice: string,
+    speed?: number,
+    voiceCatalog?: VoiceOption[],
+  ) {
     super(voice, speed);
     this.apiKey = apiKey;
     this.region = region;
+    this.dynamicVoices =
+      voiceCatalog && voiceCatalog.length > 0 ? voiceCatalog : null;
   }
 
   getVoiceOptions(): VoiceOption[] {
-    return AZURE_VOICES;
+    return this.dynamicVoices ?? AZURE_VOICES;
   }
 
   updateCredentials(settings: VoiceSettings): void {
     this.apiKey = settings.AZURE_API_KEY;
     this.region = settings.AZURE_REGION;
+    this.dynamicVoices =
+      settings.azureVoiceCatalog && settings.azureVoiceCatalog.length > 0
+        ? settings.azureVoiceCatalog
+        : null;
   }
 
   /**
@@ -180,10 +196,11 @@ export class AzureSpeechService extends BaseSpeechService {
       });
 
       if (response.status === 200) {
-        const voices = response.json ?? [];
+        const mapped = mapAzureVoices(response.json);
         return {
           isValid: true,
-          voiceCount: Array.isArray(voices) ? voices.length : undefined,
+          voiceCount: mapped.length,
+          voices: mapped,
         };
       }
       if (response.status === 401 || response.status === 403) {

--- a/src/service/SpeechProvider.ts
+++ b/src/service/SpeechProvider.ts
@@ -19,6 +19,13 @@ export interface CredentialValidationResult {
   isValid: boolean;
   error?: string;
   voiceCount?: number;
+  /**
+   * The provider's voices as a ready-to-use catalog, when validation fetched a
+   * voice list (e.g. Azure's /voices/list). Lets the settings tab cache the
+   * full catalog so the voice picker can offer every voice grouped by language,
+   * instead of only the small hardcoded fallback list.
+   */
+  voices?: VoiceOption[];
 }
 
 export interface SpeechProvider {

--- a/src/service/SpeechProviderFactory.ts
+++ b/src/service/SpeechProviderFactory.ts
@@ -35,6 +35,7 @@ export function createSpeechProvider(settings: VoiceSettings): SpeechProvider {
       settings.AZURE_REGION,
       settings.AZURE_VOICE,
       Number(settings.SPEED),
+      settings.azureVoiceCatalog,
     );
   } else if (settings.TTS_PROVIDER === "openai") {
     provider = new OpenAiSpeechService(

--- a/src/service/voiceCatalog.ts
+++ b/src/service/voiceCatalog.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure helpers for building a voice picker from a provider's voice list.
+ *
+ * Kept free of Obsidian/DOM APIs so the mapping and language-grouping logic can
+ * be unit-tested. The provider services fetch the raw list; the player view
+ * renders the grouped result as <optgroup>s.
+ */
+
+import type { VoiceOption } from "../settings/VoiceSettings";
+
+/**
+ * The subset of fields the Azure `/voices/list` endpoint returns that we use.
+ * (The endpoint returns more; we only read these.)
+ */
+export interface AzureRawVoice {
+  ShortName?: string;
+  DisplayName?: string;
+  LocalName?: string;
+  Gender?: string;
+  Locale?: string;
+  LocaleName?: string;
+  VoiceType?: string;
+  Status?: string;
+}
+
+/**
+ * Map Azure's raw voice list into the plugin's VoiceOption catalog: every
+ * Neural voice, labelled "<name> (<gender>)" and grouped by its language's
+ * display name (e.g. "English (United States)"). Non-Neural (legacy "Standard")
+ * voices are dropped — Azure has retired them and they lack SSML parity.
+ *
+ * @param raw The parsed JSON array from `/voices/list` (unknown-typed on input).
+ */
+export function mapAzureVoices(raw: unknown): VoiceOption[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const voices: VoiceOption[] = [];
+  for (const entry of raw as AzureRawVoice[]) {
+    const id = entry?.ShortName;
+    const locale = entry?.Locale;
+    if (!id || !locale || entry.VoiceType !== "Neural" || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    const name = entry.DisplayName || entry.LocalName || id;
+    const gender = entry.Gender ? ` (${entry.Gender})` : "";
+    voices.push({
+      id,
+      label: `${name}${gender}`,
+      lang: locale,
+      group: entry.LocaleName || undefined,
+    });
+  }
+  return voices;
+}
+
+/**
+ * Friendly English name for a BCP-47 locale (e.g. "de-DE" → "German (Germany)"),
+ * used to group/sort voices that don't carry an explicit `group`. Falls back to
+ * the raw code if Intl.DisplayNames is unavailable or can't resolve it.
+ */
+export function localeDisplayName(locale: string): string {
+  try {
+    const dn = new Intl.DisplayNames(["en"], { type: "language" });
+    return dn.of(locale) ?? locale;
+  } catch {
+    return locale;
+  }
+}
+
+/** A language group of voices for the picker, with its display label. */
+export interface VoiceGroup {
+  label: string;
+  voices: VoiceOption[];
+}
+
+/**
+ * Group voices by language for the picker: each group uses the voice's `group`
+ * (a provider-supplied language name) when present, otherwise a friendly name
+ * derived from its `lang`. Groups are sorted by label and the voices within
+ * each group by their own label — both case-insensitively and naturally.
+ */
+export function groupVoicesByLanguage(voices: VoiceOption[]): VoiceGroup[] {
+  const collator = new Intl.Collator(undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+  const groups = new Map<string, VoiceOption[]>();
+  for (const voice of voices) {
+    const label =
+      voice.group && voice.group.trim()
+        ? voice.group
+        : localeDisplayName(voice.lang);
+    const bucket = groups.get(label);
+    if (bucket) {
+      bucket.push(voice);
+    } else {
+      groups.set(label, [voice]);
+    }
+  }
+  return [...groups.entries()]
+    .map(([label, vs]) => ({
+      label,
+      voices: vs.slice().sort((a, b) => collator.compare(a.label, b.label)),
+    }))
+    .sort((a, b) => collator.compare(a.label, b.label));
+}

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -599,6 +599,18 @@ export class VoiceSettingTab extends PluginSettingTab {
         const result = await tempProvider.validateCredentials();
 
         if (result.isValid) {
+          // Cache a freshly fetched voice catalog (Azure) so the picker can
+          // offer every voice grouped by language, then resync the player.
+          if (
+            result.voices &&
+            result.voices.length > 0 &&
+            this.plugin.settings.TTS_PROVIDER === "azure"
+          ) {
+            this.plugin.settings.azureVoiceCatalog = result.voices;
+            await this.plugin.saveSettings();
+            this.plugin.reinitializeProviderCredentials();
+            this.plugin.refreshVoicePlayerControls();
+          }
           updateStatus(true, "", false, result.voiceCount);
         } else {
           updateStatus(false, result.error || "Validation failed", false);

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -41,6 +41,11 @@ export interface VoiceSettings {
   AZURE_API_KEY: string;
   AZURE_REGION: string;
   AZURE_VOICE: string;
+  // Azure: the full voice catalog fetched from /voices/list on "Test
+  // Credentials", cached so the picker can offer every voice grouped by
+  // language. Empty/undefined until the user validates; the hardcoded
+  // AZURE_VOICES list is the fallback.
+  azureVoiceCatalog?: VoiceOption[];
 
   // OpenAI Text-to-Speech
   OPENAI_API_KEY: string;
@@ -101,6 +106,12 @@ export interface VoiceOption {
   id: string;
   label: string;
   lang: string;
+  /**
+   * Optional display name of the language used to group the voice in the
+   * picker (e.g. "English (United States)"). Set by dynamically fetched
+   * catalogs; the hardcoded lists leave it undefined and fall back to `lang`.
+   */
+  group?: string;
 }
 
 export interface ModelOption {

--- a/src/ui/FolderPickerModal.ts
+++ b/src/ui/FolderPickerModal.ts
@@ -41,9 +41,9 @@ export class FolderPickerModal extends SuggestModal<FolderSuggestion> {
       .filter((f): f is TFolder => f instanceof TFolder)
       .map((f) => normalizeFolderPath(f.path));
 
-    this.setPlaceholder("Search folders to save audio…");
+    this.setPlaceholder("Search folders to save / move audio…");
     this.setInstructions([
-      { command: "↵", purpose: "save here" },
+      { command: "↵", purpose: "save / move here" },
       { command: "📌", purpose: "set default" },
       { command: "★", purpose: "favorite" },
       { command: "esc", purpose: "cancel" },

--- a/src/ui/FolderPickerModal.ts
+++ b/src/ui/FolderPickerModal.ts
@@ -9,7 +9,14 @@ import {
 
 /** A pickable vault folder, or the "create a new folder" affordance. */
 type FolderSuggestion =
-  | { kind: "folder"; path: string; isFavorite: boolean; isDefault: boolean }
+  | {
+      kind: "folder";
+      path: string;
+      isFavorite: boolean;
+      isDefault: boolean;
+      /** First "plain" folder below the default/favorite block — draws a divider. */
+      sectionStart?: boolean;
+    }
   | { kind: "create"; path: string };
 
 /**
@@ -77,6 +84,19 @@ export class FolderPickerModal extends SuggestModal<FolderSuggestion> {
       }),
     );
 
+    // Mark the first plain folder (neither default nor favorite) so the list
+    // shows a divider between the picked-out block at the top and the rest.
+    // Ordering puts default/favorites first, so anything before it is "picked".
+    const firstOther = matches.findIndex(
+      (m) => m.kind === "folder" && !m.isFavorite && !m.isDefault,
+    );
+    if (firstOther > 0) {
+      const item = matches[firstOther];
+      if (item.kind === "folder") {
+        item.sectionStart = true;
+      }
+    }
+
     // Offer to create a folder when the query does not name an existing one.
     const normalizedQuery = normalizeFolderPath(query.trim());
     if (q !== "" && !this.allFolders.some((p) => p.toLowerCase() === q)) {
@@ -99,8 +119,11 @@ export class FolderPickerModal extends SuggestModal<FolderSuggestion> {
       return;
     }
 
-    // Highlight the active default folder so it stands out at the top.
+    // Highlight the active default folder and favorites so they stand out at
+    // the top, and start a new section at the first plain folder below them.
     el.toggleClass("is-default", item.isDefault);
+    el.toggleClass("is-favorite", item.isFavorite);
+    el.toggleClass("is-section-start", !!item.sectionStart);
 
     const icon = el.createSpan({ cls: "voice-folder-suggestion-icon" });
     setIcon(icon, item.path === "/" ? "home" : "folder");

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -867,8 +867,8 @@ export class VoicePlayerView extends ItemView {
         this.playChapter(chapter.path),
       );
 
-      // Actions control: opens a small bar over this row with Move / Rename /
-      // Delete for this track. Stops propagation so it doesn't play.
+      // Actions control: opens a small bar over this row with Delete / Move /
+      // Rename for this track. Stops propagation so it doesn't play.
       const actionsBtn = item.createDiv({
         cls: "voice-player-chapter-edit",
         attr: { "aria-label": "Track actions" },
@@ -883,8 +883,8 @@ export class VoicePlayerView extends ItemView {
   }
 
   /**
-   * Show a small action bar laid over the chapter row with Move / Rename /
-   * Delete for that track, so the actions clearly belong to that file. Only one
+   * Show a small action bar laid over the chapter row with Delete / Move /
+   * Rename for that track, so the actions clearly belong to that file. Only one
    * bar is open at a time; clicking elsewhere or pressing Escape closes it.
    */
   private openChapterActions(item: HTMLElement, chapter: ChapterFile): void {
@@ -903,6 +903,11 @@ export class VoicePlayerView extends ItemView {
       return btn;
     };
 
+    // Order left → right: Delete, Move, Rename. Delete is left-most (next to the
+    // faded file name); Rename sits at the screen edge.
+    addBtn("Delete", () => this.showDeleteConfirm(bar, chapter)).addClass(
+      "mod-warning",
+    );
     addBtn("Move", () => {
       this.closeChapterActions();
       void this.moveChapter(chapter);
@@ -911,9 +916,6 @@ export class VoicePlayerView extends ItemView {
       this.closeChapterActions();
       this.beginRenameChapter(item, chapter);
     });
-    addBtn("Delete", () => this.showDeleteConfirm(bar, chapter)).addClass(
-      "mod-warning",
-    );
 
     this.openActionsEl = bar;
 

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -18,6 +18,7 @@ import {
 } from "../utils/chapters";
 import { attachPressGesture } from "../utils/pressGesture";
 import { noteAudioPath } from "../utils/audioFolders";
+import { groupVoicesByLanguage } from "../service/voiceCatalog";
 
 export const VIEW_TYPE_VOICE_PLAYER = "voice-player-view";
 
@@ -609,17 +610,32 @@ export class VoicePlayerView extends ItemView {
     this.updateDownloadButton();
   }
 
-  /** Rebuild the voice dropdown from the active provider's catalog. */
+  /**
+   * Rebuild the voice dropdown from the active provider's catalog, grouped by
+   * language into <optgroup>s so large catalogs (e.g. Azure's full voice list)
+   * stay navigable.
+   */
   private populateVoiceOptions(): void {
     this.voiceSelect.empty();
     const provider = this.provider();
-    provider.getVoiceOptions().forEach((voice) => {
-      this.voiceSelect.createEl("option", {
-        value: voice.id,
-        text: voice.label,
+    groupVoicesByLanguage(provider.getVoiceOptions()).forEach((group) => {
+      const optgroup = this.voiceSelect.createEl("optgroup", {
+        attr: { label: group.label },
+      });
+      group.voices.forEach((voice) => {
+        optgroup.createEl("option", { value: voice.id, text: voice.label });
       });
     });
     this.voiceSelect.value = provider.getVoice();
+  }
+
+  /**
+   * Public hook so the plugin can resync the player's selectors/toggles after
+   * settings change elsewhere (e.g. a freshly fetched voice catalog from the
+   * settings tab's "Test Credentials").
+   */
+  syncControls(): void {
+    this.refreshControls();
   }
 
   private updateCodeButton(): void {

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -201,8 +201,8 @@ export class VoicePlayerView extends ItemView {
     this.playPauseBtn = transport.createEl("button", {
       cls: "voice-player-btn voice-player-play",
       attr: {
-        "aria-label": "Play / pause — hold to regenerate",
-        title: "Tap: play, pause or cancel · Hold: regenerate from scratch",
+        "aria-label":
+          "Tap: play, pause or cancel · Hold: regenerate from scratch",
       },
     });
     setIcon(this.playPauseBtn, "play");
@@ -260,8 +260,8 @@ export class VoicePlayerView extends ItemView {
     this.folderBtn = secondary.createEl("button", {
       cls: "voice-player-folder-btn",
       attr: {
-        "aria-label": "Save to custom folder",
-        title: "Save to a folder you choose (and optionally pin it as default)",
+        "aria-label":
+          "Save or move audio to a folder you choose (optionally pin it as your default)",
       },
     });
     setIcon(this.folderBtn, "folder-open");
@@ -725,15 +725,10 @@ export class VoicePlayerView extends ItemView {
         : "Save next to the note",
     );
 
-    // Tint the folder button when a default folder is set, so it's clear a tap
-    // saves into that folder rather than next to the note.
+    // Tint the folder button when a default folder is set, so it's clear one is
+    // configured. Its tooltip stays the descriptive save/move text set at
+    // creation — the button always opens the picker regardless of the default.
     this.folderBtn.toggleClass("is-active", hasDefault);
-    this.folderBtn.setAttribute(
-      "aria-label",
-      hasDefault
-        ? `Save to default folder (${this.plugin.settings.defaultAudioFolder})`
-        : "Save to custom folder",
-    );
   }
 
   private changeSpeed(delta: number): void {

--- a/src/utils/IconEventHandler.ts
+++ b/src/utils/IconEventHandler.ts
@@ -7,6 +7,7 @@ import { FolderPickerModal } from "../ui/FolderPickerModal";
 import { FileConflictModal } from "../ui/FileConflictModal";
 import { resolveSaveFolder } from "./audioFolders";
 import { attachPressGesture } from "./pressGesture";
+import { friendlySpeechError } from "./speechFeedback";
 
 export class IconEventHandler {
   private pollyService: SpeechProvider;
@@ -524,8 +525,10 @@ export class IconEventHandler {
     // Reset spinning icons back to play state
     this.resetIconsToPlayState();
 
-    // Show error notification to user
-    new Notice(`🔊 Voice Plugin: ${errorMessage}`, 5000);
+    // Show error notification to user. Map internal synthesis details (SSML
+    // build/chunking) to a friendly message; actionable provider messages
+    // (invalid key, quota) pass through unchanged.
+    new Notice(`🔊 Voice Plugin: ${friendlySpeechError(errorMessage)}`, 5000);
 
     // Auto-hide error after 3 seconds
     window.setTimeout(() => {

--- a/src/utils/MarkdownHelper.ts
+++ b/src/utils/MarkdownHelper.ts
@@ -1,5 +1,14 @@
 import { MarkdownView, TFile, App } from "obsidian";
 
+/**
+ * Outcome of reading the note to speak: the text on success, or a reason the
+ * caller can turn into friendly user feedback. Returning a result (rather than
+ * a sentinel string) keeps an error message from being read aloud as content.
+ */
+export type NoteReadResult =
+  | { ok: true; text: string }
+  | { ok: false; reason: "no-note" | "read-error" };
+
 export class MarkdownHelper {
   private app: App;
 
@@ -7,12 +16,15 @@ export class MarkdownHelper {
     this.app = app;
   }
 
-  async getMarkdownView(): Promise<string> {
+  async getMarkdownView(): Promise<NoteReadResult> {
     // First, try the active MarkdownView: read its selection if any, else all.
     const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
     if (activeView) {
       const selectedText = activeView.editor.getSelection();
-      return selectedText ? selectedText : activeView.editor.getValue();
+      return {
+        ok: true,
+        text: selectedText ? selectedText : activeView.editor.getValue(),
+      };
     }
 
     // No MarkdownView is active — this is the case when reading is triggered
@@ -31,21 +43,21 @@ export class MarkdownHelper {
       if (fileView) {
         const selectedText = fileView.editor.getSelection();
         if (selectedText) {
-          return selectedText;
+          return { ok: true, text: selectedText };
         }
       }
 
       try {
         // No selection (or no open editor) — read the file content directly.
-        return await this.app.vault.cachedRead(activeFile);
+        return { ok: true, text: await this.app.vault.cachedRead(activeFile) };
       } catch (error) {
         console.error("Error reading active file:", error);
-        return "Error reading the active file.";
+        return { ok: false, reason: "read-error" };
       }
     }
 
-    // If no active file is found, return the error message
-    return "No active file found.";
+    // No note is open to read.
+    return { ok: false, reason: "no-note" };
   }
 
   getActiveFilePath(): string | null {

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -3,6 +3,12 @@ import { MarkdownHelper } from "./MarkdownHelper";
 import { IconEventHandler } from "./IconEventHandler";
 import { MarkdownToSSMLProcessor } from "../processors/MarkdownToSSMLProcessor";
 import { MarkdownToTextProcessor } from "../processors/MarkdownToTextProcessor";
+import {
+  NO_NOTE_MESSAGE,
+  EMPTY_NOTE_MESSAGE,
+  READ_ERROR_MESSAGE,
+  friendlySpeechError,
+} from "./speechFeedback";
 import { Notice } from "obsidian";
 
 /**
@@ -79,11 +85,25 @@ export class TextSpeaker {
     const requestId = this.provider.startOperation();
 
     try {
-      // Get raw markdown content
-      const rawText = await this.markdownHelper.getMarkdownView();
+      // Get the note text to read (or a reason it couldn't be read)
+      const read = await this.markdownHelper.getMarkdownView();
 
       // Validate request still active after async operation
       if (!this.provider.isCurrentRequest(requestId)) {
+        return;
+      }
+
+      // Friendly feedback instead of reading an error string aloud: no note
+      // open, an unreadable note, or a note with no text to speak.
+      if (!read.ok) {
+        new Notice(
+          read.reason === "no-note" ? NO_NOTE_MESSAGE : READ_ERROR_MESSAGE,
+        );
+        return;
+      }
+      const rawText = read.text;
+      if (rawText.trim() === "") {
+        new Notice(EMPTY_NOTE_MESSAGE);
         return;
       }
 
@@ -123,7 +143,7 @@ export class TextSpeaker {
       console.error("Error in text-to-speech processing:", error);
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      new Notice(`Voice Plugin Error: ${errorMessage}`);
+      new Notice(friendlySpeechError(errorMessage));
     } finally {
       // Always cleanup operation, even if cancelled or error occurred
       this.provider.endOperation(requestId);
@@ -144,7 +164,9 @@ export class TextSpeaker {
     if (!result.isValid) {
       console.error("SSML validation errors:", result.errors);
       new Notice(
-        `Voice Plugin: SSML validation failed\n${result.errors.join("\n")}`,
+        friendlySpeechError(
+          `SSML validation failed: ${result.errors.join("; ")}`,
+        ),
       );
       return null;
     }

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -129,8 +129,20 @@ export class TextSpeaker {
       // Get current file path for caching
       const activeFilePath = this.markdownHelper.getActiveFilePath();
 
-      // Hand the processed content to the active provider
-      await this.provider.speak(content, speed, activeFilePath || undefined);
+      // Hand the processed content to the active provider. The provider already
+      // surfaces its own failures through the error callback (a single friendly
+      // notice via IconEventHandler), so swallow the re-thrown error here rather
+      // than showing a duplicate notice; the outer catch only handles errors
+      // that don't come from synthesis (e.g. the content pipeline).
+      try {
+        await this.provider.speak(content, speed, activeFilePath || undefined);
+      } catch (speakError) {
+        if (speakError instanceof Error && speakError.name === "AbortError") {
+          return;
+        }
+        console.error("Speech synthesis failed:", speakError);
+        return;
+      }
 
       // Auto-save the generated audio to the note if the user enabled it
       await this.iconEventHandler.maybeAutoDownloadAudio();

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -193,6 +193,21 @@ export class Voice extends Plugin {
     this.reinitializeTextSpeaker();
   }
 
+  /**
+   * Resync any open Voice player panes with the current settings/provider —
+   * used after the settings tab changes something the player shows (e.g. a
+   * freshly fetched voice catalog), so its voice picker updates immediately.
+   */
+  public refreshVoicePlayerControls(): void {
+    this.app.workspace
+      .getLeavesOfType(VIEW_TYPE_VOICE_PLAYER)
+      .forEach((leaf) => {
+        if (leaf.view instanceof VoicePlayerView) {
+          leaf.view.syncControls();
+        }
+      });
+  }
+
   public reinitializeTextSpeaker(): void {
     // Recreate TextSpeaker with updated settings + current provider
     this.textSpeaker = new TextSpeaker(

--- a/src/utils/speechFeedback.ts
+++ b/src/utils/speechFeedback.ts
@@ -1,0 +1,36 @@
+/**
+ * User-facing feedback for the read-aloud flow.
+ *
+ * Centralizes the short, friendly messages shown as Obsidian notices so the
+ * wording stays consistent across providers, and maps raw thrown errors to a
+ * friendly message — internal SSML/chunking details should never reach the
+ * user. Kept free of Obsidian APIs so the mapping is unit-tested; the notices
+ * themselves are shown by TextSpeaker.
+ */
+
+/** Shown when the play/read action runs with no note open. */
+export const NO_NOTE_MESSAGE = "No note open — open a note to read it aloud.";
+
+/** Shown when the active note has no readable text. */
+export const EMPTY_NOTE_MESSAGE = "This note has no text to read.";
+
+/** Shown when the active note can't be read from disk. */
+export const READ_ERROR_MESSAGE =
+  "Couldn't read the active note. Please try again.";
+
+/** Shown when preparing the note for synthesis fails (SSML build/chunking). */
+export const PREPARE_ERROR_MESSAGE =
+  "Couldn't prepare this note for speech. It may contain unusual formatting — try again or simplify the note.";
+
+/**
+ * Map a raw thrown error message to a friendly, user-facing one. Internal
+ * SSML/chunking details are replaced with a single readable message; already
+ * user-facing provider messages (invalid credentials, network, quota) pass
+ * through unchanged so they stay actionable.
+ */
+export function friendlySpeechError(raw: string): string {
+  if (/ssml\s+(chunking|validation)|unbalanced tag/i.test(raw)) {
+    return PREPARE_ERROR_MESSAGE;
+  }
+  return raw;
+}

--- a/src/utils/whatsNew.ts
+++ b/src/utils/whatsNew.ts
@@ -73,7 +73,7 @@ Voice started out as AWS Polly only — now it supports all the major engines, s
 - **ElevenLabs** — premade & multilingual voices.
 - **OpenAI** — built-in voices (Alloy, Nova, …) with GPT-4o mini TTS.
 - **Google Cloud Text-to-Speech** — plus extra hotkey commands.
-- **Azure AI Speech** — neural voices across many languages.
+- **Azure AI Speech** — neural voices across many languages. **New:** press **Test Credentials** and Voice loads your account's full Azure catalog (hundreds of voices), grouped by language in the picker.
 
 **Your audio files**
 

--- a/styles.css
+++ b/styles.css
@@ -767,9 +767,11 @@
   cursor: pointer;
 }
 
-/* Action bar over a chapter row: Move / Rename / Delete. Right-aligned and only
+/* Action bar over a chapter row: Delete / Move / Rename. Right-aligned and only
    as wide as its buttons, with the background fading out to the left so the
-   start of the file name stays readable underneath. */
+   start of the file name stays readable underneath. The buttons share the bar's
+   surface as flat text labels (no separate button pills), so nothing spills
+   outside the bar. */
 .voice-player-chapter-actions {
   position: absolute;
   top: 0;
@@ -778,21 +780,44 @@
   z-index: 5;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 0 6px 0 28px;
+  gap: 2px;
+  padding: 0 4px 0 32px;
   border-radius: var(--radius-s);
   background: linear-gradient(
     to right,
     transparent 0,
-    var(--background-secondary-alt) 28px
+    var(--background-secondary-alt) 32px
   );
 }
 
 .voice-player-chapter-action {
-  flex: 0 1 auto;
-  padding: 2px 10px;
+  flex: 0 0 auto;
+  padding: 4px 9px;
+  height: auto;
   font-size: var(--font-ui-smaller);
+  line-height: 1.2;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  border-radius: var(--radius-s);
   cursor: pointer;
+}
+
+.voice-player-chapter-action:hover {
+  color: var(--text-normal);
+  background: var(--background-modifier-hover);
+}
+
+.voice-player-chapter-action.mod-warning {
+  color: var(--text-error);
+  background: transparent;
+  box-shadow: none;
+}
+
+.voice-player-chapter-action.mod-warning:hover {
+  color: var(--text-error);
+  background: var(--background-modifier-hover);
 }
 
 .voice-player-chapter-confirm {

--- a/styles.css
+++ b/styles.css
@@ -1043,7 +1043,37 @@
 
 .voice-folder-suggestion-pin:hover,
 .voice-folder-suggestion-pin.is-default,
-.voice-folder-suggestion-star:hover,
-.voice-folder-suggestion-star.is-favorite {
+.voice-folder-suggestion-star:hover {
   color: var(--text-accent);
+}
+
+/* Favorites use a distinct gold accent so they read differently from the
+   purple default: the star and the folder icon on the left both pick it up.
+   The default (purple) wins on the icon when a folder is both. */
+.voice-folder-suggestion-star.is-favorite {
+  color: var(--color-yellow);
+}
+
+.voice-folder-suggestion.is-favorite:not(.is-default)
+  .voice-folder-suggestion-icon {
+  color: var(--color-yellow);
+}
+
+/* Visual break between the default/favorite block at the top and all other
+   folders, with a small caption so the two sections read distinctly. */
+.voice-folder-suggestion.is-section-start {
+  position: relative;
+  margin-top: 22px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.voice-folder-suggestion.is-section-start::before {
+  content: "Other folders";
+  position: absolute;
+  left: 0;
+  top: -18px;
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }

--- a/tests/azure.unit.test.ts
+++ b/tests/azure.unit.test.ts
@@ -41,10 +41,33 @@ describe("Unit Tests - Azure Speech Provider", () => {
       expect(mockRequestUrl).not.toHaveBeenCalled();
     });
 
-    test("reports voice count on a successful response", async () => {
+    test("reports the mapped voices and count on a successful response", async () => {
       mockRequestUrl.mockResolvedValue({
         status: 200,
-        json: [{ ShortName: "a" }, { ShortName: "b" }],
+        json: [
+          {
+            ShortName: "en-US-JennyNeural",
+            DisplayName: "Jenny",
+            Gender: "Female",
+            Locale: "en-US",
+            LocaleName: "English (United States)",
+            VoiceType: "Neural",
+          },
+          {
+            ShortName: "de-DE-ConradNeural",
+            DisplayName: "Conrad",
+            Gender: "Male",
+            Locale: "de-DE",
+            LocaleName: "German (Germany)",
+            VoiceType: "Neural",
+          },
+          // Legacy non-Neural voice — excluded from the catalog and the count.
+          {
+            ShortName: "en-US-ZiraRUS",
+            Locale: "en-US",
+            VoiceType: "Standard",
+          },
+        ],
       });
       const service = new AzureSpeechService(
         "key",
@@ -54,6 +77,10 @@ describe("Unit Tests - Azure Speech Provider", () => {
       const result = await service.validateCredentials();
       expect(result.isValid).toBe(true);
       expect(result.voiceCount).toBe(2);
+      expect(result.voices?.map((v) => v.id)).toEqual([
+        "en-US-JennyNeural",
+        "de-DE-ConradNeural",
+      ]);
     });
 
     test("treats HTTP 401 as an invalid key/region", async () => {

--- a/tests/speech-feedback.unit.test.ts
+++ b/tests/speech-feedback.unit.test.ts
@@ -1,0 +1,49 @@
+import {
+  friendlySpeechError,
+  PREPARE_ERROR_MESSAGE,
+  NO_NOTE_MESSAGE,
+  EMPTY_NOTE_MESSAGE,
+  READ_ERROR_MESSAGE,
+} from "../src/utils/speechFeedback";
+
+describe("Unit Tests - Speech feedback", () => {
+  describe("friendlySpeechError", () => {
+    test("replaces SSML chunking internals with a friendly message", () => {
+      const raw =
+        "SSML chunking failed: Chunk 1 has unbalanced tags (31 open, 29 close)";
+      expect(friendlySpeechError(raw)).toBe(PREPARE_ERROR_MESSAGE);
+    });
+
+    test("replaces SSML validation internals with a friendly message", () => {
+      expect(friendlySpeechError("SSML validation failed: bad node")).toBe(
+        PREPARE_ERROR_MESSAGE,
+      );
+    });
+
+    test("replaces a bare unbalanced-tag message", () => {
+      expect(friendlySpeechError("Chunk 2 has unbalanced tags")).toBe(
+        PREPARE_ERROR_MESSAGE,
+      );
+    });
+
+    test("passes through actionable provider messages unchanged", () => {
+      const credential = "Azure Speech: invalid key or region (401)";
+      const quota = "Azure Speech: rate or quota limit reached (429)";
+      expect(friendlySpeechError(credential)).toBe(credential);
+      expect(friendlySpeechError(quota)).toBe(quota);
+    });
+  });
+
+  describe("messages", () => {
+    test("all user-facing messages are non-empty and distinct", () => {
+      const messages = [
+        NO_NOTE_MESSAGE,
+        EMPTY_NOTE_MESSAGE,
+        READ_ERROR_MESSAGE,
+        PREPARE_ERROR_MESSAGE,
+      ];
+      messages.forEach((m) => expect(m.length).toBeGreaterThan(0));
+      expect(new Set(messages).size).toBe(messages.length);
+    });
+  });
+});

--- a/tests/voice-catalog.unit.test.ts
+++ b/tests/voice-catalog.unit.test.ts
@@ -1,0 +1,125 @@
+import {
+  mapAzureVoices,
+  groupVoicesByLanguage,
+  localeDisplayName,
+} from "../src/service/voiceCatalog";
+import type { VoiceOption } from "../src/settings/VoiceSettings";
+
+describe("Unit Tests - Voice catalog", () => {
+  describe("mapAzureVoices", () => {
+    const raw = [
+      {
+        ShortName: "en-US-JennyNeural",
+        DisplayName: "Jenny",
+        Gender: "Female",
+        Locale: "en-US",
+        LocaleName: "English (United States)",
+        VoiceType: "Neural",
+        Status: "GA",
+      },
+      {
+        ShortName: "de-DE-ConradNeural",
+        DisplayName: "Conrad",
+        Gender: "Male",
+        Locale: "de-DE",
+        LocaleName: "German (Germany)",
+        VoiceType: "Neural",
+        Status: "GA",
+      },
+      {
+        // Legacy non-Neural voice — must be dropped.
+        ShortName: "en-US-ZiraRUS",
+        DisplayName: "Zira",
+        Gender: "Female",
+        Locale: "en-US",
+        LocaleName: "English (United States)",
+        VoiceType: "Standard",
+        Status: "GA",
+      },
+    ];
+
+    test("maps Neural voices to VoiceOptions with label, lang and group", () => {
+      const voices = mapAzureVoices(raw);
+      expect(voices).toContainEqual({
+        id: "en-US-JennyNeural",
+        label: "Jenny (Female)",
+        lang: "en-US",
+        group: "English (United States)",
+      });
+      expect(voices).toContainEqual({
+        id: "de-DE-ConradNeural",
+        label: "Conrad (Male)",
+        lang: "de-DE",
+        group: "German (Germany)",
+      });
+    });
+
+    test("drops non-Neural (legacy) voices", () => {
+      const ids = mapAzureVoices(raw).map((v) => v.id);
+      expect(ids).not.toContain("en-US-ZiraRUS");
+      expect(ids).toHaveLength(2);
+    });
+
+    test("skips entries missing a ShortName or Locale", () => {
+      const voices = mapAzureVoices([
+        { DisplayName: "NoId", Gender: "Female", VoiceType: "Neural" },
+        { ShortName: "x-Neural", Gender: "Male", VoiceType: "Neural" },
+      ]);
+      expect(voices).toHaveLength(0);
+    });
+
+    test("dedupes by ShortName", () => {
+      const dup = [raw[0], raw[0]];
+      expect(mapAzureVoices(dup)).toHaveLength(1);
+    });
+
+    test("returns an empty list for non-array input", () => {
+      expect(mapAzureVoices(null)).toEqual([]);
+      expect(mapAzureVoices(undefined)).toEqual([]);
+      expect(mapAzureVoices("nope")).toEqual([]);
+    });
+  });
+
+  describe("groupVoicesByLanguage", () => {
+    test("groups by the provided group label and sorts groups + voices", () => {
+      const voices: VoiceOption[] = [
+        { id: "b", label: "Bravo", lang: "de-DE", group: "German (Germany)" },
+        {
+          id: "a",
+          label: "Alpha",
+          lang: "en-US",
+          group: "English (United States)",
+        },
+        { id: "c", label: "Charlie", lang: "de-DE", group: "German (Germany)" },
+      ];
+      const groups = groupVoicesByLanguage(voices);
+      expect(groups.map((g) => g.label)).toEqual([
+        "English (United States)",
+        "German (Germany)",
+      ]);
+      // German group keeps both voices, sorted by label.
+      expect(groups[1].voices.map((v) => v.label)).toEqual([
+        "Bravo",
+        "Charlie",
+      ]);
+    });
+
+    test("falls back to a language name derived from lang when no group", () => {
+      const voices: VoiceOption[] = [
+        { id: "x", label: "Vicki", lang: "de-DE" },
+      ];
+      const groups = groupVoicesByLanguage(voices);
+      expect(groups).toHaveLength(1);
+      // Whatever Intl resolves to, it must be a non-empty label for the group.
+      expect(groups[0].label.length).toBeGreaterThan(0);
+      expect(groups[0].voices[0].id).toBe("x");
+    });
+  });
+
+  describe("localeDisplayName", () => {
+    test("returns a non-empty label (friendly name or the raw code)", () => {
+      expect(localeDisplayName("de-DE").length).toBeGreaterThan(0);
+      expect(localeDisplayName("en-US").length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces every Azure voice (grouped by language) instead of a hardcoded handful, and rounds out the player with clearer feedback and folder-picker UX. Pressing play with no readable note now shows a short, friendly notice instead of reading an error aloud or dumping raw SSML internals, and the release workflow correctly bumps the minor version for scoped `feat(...)` commits.

Closes #60

## Type of change

- [x] feat — new feature (minor)
- [x] fix — bug fix (patch)
- [x] docs — documentation only
- [ ] refactor / chore — no user-facing change
- [ ] BREAKING CHANGE (explain below)

> Mixed `feat`/`fix`/`style`/`docs`. Settings gain optional fields with safe defaults — no breaking change.

## Changes

**Azure: every voice, grouped by language (#60)**
- "Test Credentials" already fetched the full `/voices/list` to count voices, then discarded it. That list is now mapped to the plugin's catalog (every Neural voice, labelled `<name> (<gender>)` with its language name), cached in `settings.azureVoiceCatalog`, and returned by the Azure service's `getVoiceOptions()` — the curated `AZURE_VOICES` stays as the fallback until validation runs.
- The player's voice dropdown renders the catalog as `<optgroup>`s grouped by language, so the large list stays navigable.
- New pure, unit-tested `service/voiceCatalog.ts` (`mapAzureVoices`, `groupVoicesByLanguage`, `localeDisplayName`); `CredentialValidationResult` gains an optional `voices[]`; the settings tab caches it and resyncs open player panes.

**Friendlier read-aloud feedback (no more scary errors)**
- `MarkdownHelper.getMarkdownView()` returns a typed result instead of a sentinel string, so an unread state can never be spoken aloud.
- Short, friendly notices for: no note open, an unreadable note, and a note with no text to read.
- Raw synthesis errors (SSML build/chunking) map to one friendly message; actionable provider messages (invalid key, quota) still pass through, with technical detail kept in the console.
- Fixes the **duplicate** error notice: providers both `reportError` and re-throw, so a failure showed two notices. `IconEventHandler.handleError` now maps through the same friendly helper, and `TextSpeaker` swallows the re-thrown synthesis error — exactly one friendly notice. Messages live in pure, unit-tested `utils/speechFeedback.ts`.

**Folder picker**
- Favorites use a gold accent on the star **and** the left folder icon, so they read distinctly from the purple default; a divider with an "Other folders" caption separates the default/favorite block from the rest.
- Search placeholder and the enter hint now mention **move** as well as save ("Search folders to save / move audio…", "save / move here").

**Player polish**
- Per-chapter action bar reordered to **Delete / Move / Rename** and flattened (flat text labels that share the bar's surface, no spilling button pills).
- One tooltip per button: dropped the native `title` that doubled up with the `aria-label`; the folder button's tooltip now clearly states it can **save or move** audio.

**Release pipeline**
- `paulhatch/semantic-version` patterns are now regexes that allow an optional scope and `!`, so `feat(player): …` triggers a **minor** bump (it previously fell back to patch).

## Provider impact

- [ ] None
- [ ] AWS Polly
- [ ] ElevenLabs
- [ ] OpenAI
- [ ] Google Cloud
- [x] Azure Speech

> Azure gains the dynamic voice catalog. The friendly-feedback and duplicate-notice fixes are provider-agnostic (they run in the shared orchestration/error path), so all five engines benefit, but no other engine's behaviour changed.

## Platform impact

- [x] Desktop
- [x] Mobile (iOS / Android)

## How to test

1. **Azure voices (#60)**: pick **Azure Speech**, enter key + region, press **Test Credentials**. The player's voice dropdown fills with your account's voices, grouped by language.
2. **No note / empty note**: focus away from any note (or open an empty one) and tap play in the player → a single friendly notice ("No note open…" / "This note has no text to read."), nothing read aloud.
3. **Synthesis error**: trigger a note that fails to chunk → exactly one friendly notice ("Couldn't prepare this note for speech…"), not the raw "unbalanced tags" text, and no duplicate.
4. **Folder picker**: open it; favorites show a gold star + gold folder icon, the default shows the purple accent + "Default" badge, and an "Other folders" divider separates them. Placeholder/hint mention save / move.
5. **Chapter actions**: the **⋮** bar reads Delete / Move / Rename and sits cleanly within its background.
6. **Tooltips**: hover the play and folder buttons → a single tooltip each.
7. Repeat the key flows on mobile.

## Checklist

- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm run lint:check` passes
- [x] `npm test` passes (160 tests)
- [x] Added/updated tests where it makes sense
- [x] Updated docs (README / What's New / CLAUDE.md) where behaviour changed
- [x] PR title follows Conventional Commits
- [x] No secrets/credentials committed

## Screenshots / recordings

Player, folder picker, and the single friendly notice are easiest to see live; before/after recordings welcome during review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyFh958nxJcV1SgxvsUxyh)_