### PR TITLE
feat(provider): add Piper local TTS engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Obsidian Voice Plugin 🔊
 
-![Obsidian Voice — listen to your notes in natural, lifelike speech with AWS Polly, ElevenLabs, Google Cloud, Azure Speech, or OpenAI](./assets/hero.png)
+![Obsidian Voice — listen to your notes in natural, lifelike speech with AWS Polly, ElevenLabs, Google Cloud, Azure Speech, OpenAI, or Piper](./assets/hero.png)
 
-Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian Voice Plugin reads your notes aloud in natural, lifelike speech — using the text-to-speech provider you already have. It supports all the major engines — **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, and **Azure Speech** — so you can listen with whichever one you prefer. Listen with a dedicated player, jump between notes like chapters, change the speed on the fly, and save audio offline — with your credentials kept private in your own account.
+Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian Voice Plugin reads your notes aloud in natural, lifelike speech — using the text-to-speech provider you already have. It supports all the major engines — **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, **Azure Speech**, and **Piper** — so you can listen with whichever one you prefer. Listen with a dedicated player, jump between notes like chapters, change the speed on the fly, and save audio offline — with your credentials kept private in your own account.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 ## Highlights
 
 - **A real audiobook player** — open the Voice player, see your notes as chapters, and play, skip, and repeat just like a podcast app.
-- **Bring your own provider** — Voice supports all the major text-to-speech engines (**AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, and **Azure Speech**), so you can listen with whichever one you already use. Every feature works the same on all of them.
+- **Bring your own provider** — Voice supports all the major text-to-speech engines (**AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, **Azure Speech**, and **Piper**), so you can listen with whichever one you already use. Every feature works the same on all of them.
 - **Listen in seconds** — turn any note into lifelike speech straight from the ribbon, a command, or the player.
 - **Designed for every device** — the same experience on desktop, iOS, and Android, with a touch-friendly mobile player and control bar.
 - **Own your audio** — download MP3 files, auto-embed them into your note, and keep an offline archive.
@@ -166,7 +166,7 @@ Configure your provider and credentials in **Settings → Voice**. The settings 
 
 | Setting                         | What it does                                                                                                                                                                                                                                                                              |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Speech Provider**             | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI**. The credential fields below adapt to your choice.                                                                                                                                    |
+| **Speech Provider**             | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, **OpenAI**, or **Piper (local)**. The credential fields below adapt to your choice.                                                                                                                 |
 | **Rewind interval**             | How many seconds the rewind control jumps back (1–60s, default 3s).                                                                                                                                                                                                                       |
 | **Fast-forward interval**       | How many seconds the fast-forward control jumps ahead (1–60s, default 3s).                                                                                                                                                                                                                |
 | **Save automatically**          | Automatically save and embed the MP3 after each playback. Off by default.                                                                                                                                                                                                                 |
@@ -200,14 +200,14 @@ Voice ships **16 commands** you can bind to any hotkey. No keys are assigned by 
 
 ## Bring Your Own Provider
 
-Voice is built to work with the provider you already use. For a long time it was AWS Polly only — the goal now is to support all the common text-to-speech engines, so you can bring your own. Pick **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, or **Azure Speech** from the **Speech Provider** dropdown in settings. Each provider keeps its own credentials and voice list; everything else — tempo, rewind/fast-forward intervals, downloads, auto-save, and the content toggles — works identically. After entering your credentials, press **Test Credentials** to confirm everything is connected.
+Voice is built to work with the provider you already use. For a long time it was AWS Polly only — the goal now is to support all the common text-to-speech engines, so you can bring your own. Pick **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, **Azure Speech**, or **Piper (local)** from the **Speech Provider** dropdown in settings. Each provider keeps its own credentials and voice list; everything else — tempo, rewind/fast-forward intervals, downloads, auto-save, and the content toggles — works identically. After entering your credentials, press **Test Credentials** to confirm everything is connected.
 
-|                 | **AWS Polly**                       | **ElevenLabs**                                      | **Google Cloud**                                  | **Azure Speech**                    | **OpenAI**                                    |
-| --------------- | ----------------------------------- | --------------------------------------------------- | ------------------------------------------------- | ----------------------------------- | --------------------------------------------- |
-| **Voices**      | Neural voices across many languages | Premade & multilingual voices speaking 29 languages | Neural2 & WaveNet voices across many languages    | Neural voices across many languages | Built-in multilingual voices (Alloy, Nova, …) |
-| **Credentials** | AWS region + Access Key ID & Secret | ElevenLabs API key                                  | Google Cloud API key (Text-to-Speech API enabled) | Azure Speech key + region           | OpenAI API key                                |
-| **Emphasis**    | Native SSML pauses & emphasis       | Expressive models with natural `<break>` pauses     | Native SSML pauses & emphasis                     | Native SSML pauses & emphasis       | Natural prosody (no SSML)                     |
-| **Models**      | Neural engine                       | Multilingual v2 / Flash v2.5 / Turbo v2.5           | Neural2 / WaveNet                                 | Neural                              | GPT-4o mini TTS / TTS-1 / TTS-1 HD            |
+|                 | **AWS Polly**                       | **ElevenLabs**                                      | **Google Cloud**                                  | **Azure Speech**                    | **OpenAI**                                    | **Piper**                                               |
+| --------------- | ----------------------------------- | --------------------------------------------------- | ------------------------------------------------- | ----------------------------------- | --------------------------------------------- | ------------------------------------------------------- |
+| **Voices**      | Neural voices across many languages | Premade & multilingual voices speaking 29 languages | Neural2 & WaveNet voices across many languages    | Neural voices across many languages | Built-in multilingual voices (Alloy, Nova, …) | Locally installed neural voice models                   |
+| **Credentials** | AWS region + Access Key ID & Secret | ElevenLabs API key                                  | Google Cloud API key (Text-to-Speech API enabled) | Azure Speech key + region           | OpenAI API key                                | None — self-hosted HTTP server                          |
+| **Emphasis**    | Native SSML pauses & emphasis       | Expressive models with natural `<break>` pauses     | Native SSML pauses & emphasis                     | Native SSML pauses & emphasis       | Natural prosody (no SSML)                     | Plain text (no SSML)                                    |
+| **Models**      | Neural engine                       | Multilingual v2 / Flash v2.5 / Turbo v2.5           | Neural2 / WaveNet                                 | Neural                              | GPT-4o mini TTS / TTS-1 / TTS-1 HD            | Any [Piper voice model](https://huggingface.co/rhasspy) |
 
 ## Getting Started
 
@@ -230,6 +230,8 @@ Start with the provider you already have — you can switch anytime.
 **Azure Speech** — In the [Azure portal](https://portal.azure.com/), create a **Speech** resource and copy a **Key** and **Region**. In **Settings → Voice**, choose **Azure Speech**, select the matching region, pick a voice, paste the key, and press **Test Credentials**.
 
 **OpenAI** — Create an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys). In **Settings → Voice**, choose **OpenAI**, pick a model and voice, paste the key, and press **Test Credentials**.
+
+**Piper (local)** — Install and start a [Piper TTS HTTP server](https://github.com/OHF-Voice/piper1-gpl) on your machine (or somewhere reachable on your network). In **Settings → Voice**, choose **Piper (local)** and enter the server URL (default `http://localhost:5000`). Optionally type a voice model name (e.g. `en_US-lessac-medium`); leave blank to use whatever model the server has loaded. Click **Test Connection** to confirm the server is reachable and to load the available voice list. No account or API key required.
 
 ## Troubleshooting & Help
 

--- a/src/service/BaseSpeechService.ts
+++ b/src/service/BaseSpeechService.ts
@@ -49,6 +49,7 @@ export abstract class BaseSpeechService implements SpeechProvider {
   // --- Provider-specific members implemented by subclasses ---
 
   abstract readonly inputFormat: "ssml" | "text";
+  readonly supportsBreakTags: boolean = true;
   abstract speak(
     content: string,
     speed?: number,

--- a/src/service/PiperService.ts
+++ b/src/service/PiperService.ts
@@ -51,20 +51,16 @@ export class PiperService extends BaseSpeechService {
    * "/synthesize" for OHF-Voice/piper1-gpl; "/" for legacy rhasspy/piper.
    */
   private synthesisPath: string | null = null;
+  private voiceCatalog: VoiceOption[];
 
-  constructor(serverUrl: string, voice: string, speed?: number) {
+  constructor(serverUrl: string, voice: string, speed?: number, voiceCatalog?: VoiceOption[]) {
     super(voice, speed);
     this.serverUrl = normalizeUrl(serverUrl);
+    this.voiceCatalog = voiceCatalog ?? [];
   }
 
   getVoiceOptions(): VoiceOption[] {
-    // Piper voices are local model files with no fixed catalog. The list is
-    // populated at runtime by validateCredentials() fetching /voices from the
-    // running server, and cached in settings.piperVoiceCatalog by the settings
-    // tab (same pattern as Azure). An empty array here is intentional - the
-    // player always uses getVoiceOptions() from the live provider instance,
-    // which VoicePlugin keeps in sync via reinitializeProviderCredentials().
-    return [];
+    return this.voiceCatalog;
   }
 
   updateCredentials(settings: VoiceSettings): void {
@@ -75,6 +71,7 @@ export class PiperService extends BaseSpeechService {
     }
     this.serverUrl = newUrl;
     this.voice = settings.PIPER_VOICE ?? "";
+    this.voiceCatalog = settings.piperVoiceCatalog ?? [];
   }
 
   /**

--- a/src/service/PiperService.ts
+++ b/src/service/PiperService.ts
@@ -1,0 +1,263 @@
+import { requestUrl } from "obsidian";
+import type { VoiceOption, VoiceSettings } from "../settings/VoiceSettings";
+import { PIPER_DEFAULT_URL } from "../settings/VoiceSettings";
+import { BaseSpeechService } from "./BaseSpeechService";
+import type { CredentialValidationResult } from "./SpeechProvider";
+import { chunkPlainText } from "./textChunker";
+
+/**
+ * Piper local Text-to-Speech integration.
+ *
+ * Supports two server generations:
+ *   - rhasspy/piper  (v1.0.0, archived) - synthesis at POST /
+ *   - OHF-Voice/piper1-gpl (v1.4+, current) - synthesis at POST /synthesize
+ *
+ * The service auto-detects which endpoint the running server uses on the first
+ * synthesis call and caches the result for subsequent calls.
+ *
+ * Requirements for the user:
+ *   pip install "piper-tts[http]"
+ *   python3 -m piper.download_voices <voice-name>
+ *   python3 -m piper.http_server -m <voice-name>   # defaults to port 5000
+ *
+ * Speed mapping: Piper's length_scale is the inverse of the plugin's speed
+ * multiplier (length_scale = 1 / speed). Plugin 2x (fast) -> length_scale 0.5;
+ * plugin 0.5x (slow) -> length_scale 2.0.
+ *
+ * Output: WAV audio (not MP3). AudioFileManager derives the file extension
+ * from the blob MIME type, so saved files are written as .wav.
+ *
+ * Playback/controls/caching are inherited from BaseSpeechService.
+ */
+
+// Conservative per-request size. Piper has no documented character limit but
+// smaller chunks reduce per-request latency and avoid edge-case timeouts on
+// very long documents. Matches the SSML pipeline's chunk target.
+const MAX_CHUNK_CHARS = 3000;
+
+/** OHF-Voice/piper1-gpl (v1.4+) synthesis endpoint. */
+const PATH_SYNTHESIZE = "/synthesize";
+/** Legacy rhasspy/piper (v1.0.0) synthesis endpoint. */
+const PATH_ROOT = "/";
+const PATH_VOICES = "/voices";
+
+export class PiperService extends BaseSpeechService {
+  readonly inputFormat = "text" as const;
+  readonly supportsBreakTags = false as const;
+
+  private serverUrl: string;
+  /**
+   * Cached synthesis path - null until first detection.
+   * "/synthesize" for OHF-Voice/piper1-gpl; "/" for legacy rhasspy/piper.
+   */
+  private synthesisPath: string | null = null;
+
+  constructor(serverUrl: string, voice: string, speed?: number) {
+    super(voice, speed);
+    this.serverUrl = normalizeUrl(serverUrl);
+  }
+
+  getVoiceOptions(): VoiceOption[] {
+    // Piper voices are local model files with no fixed catalog. The list is
+    // populated at runtime by validateCredentials() fetching /voices from the
+    // running server, and cached in settings.piperVoiceCatalog by the settings
+    // tab (same pattern as Azure). An empty array here is intentional - the
+    // player always uses getVoiceOptions() from the live provider instance,
+    // which VoicePlugin keeps in sync via reinitializeProviderCredentials().
+    return [];
+  }
+
+  updateCredentials(settings: VoiceSettings): void {
+    const newUrl = normalizeUrl(settings.PIPER_URL);
+    if (newUrl !== this.serverUrl) {
+      // Reset cached path so detection reruns for the new server.
+      this.synthesisPath = null;
+    }
+    this.serverUrl = newUrl;
+    this.voice = settings.PIPER_VOICE ?? "";
+  }
+
+  /**
+   * Validate the connection by fetching /voices from the Piper HTTP server.
+   * Returns the list of available voices so the settings tab can cache them.
+   */
+  async validateCredentials(): Promise<CredentialValidationResult> {
+    try {
+      const res = await requestUrl({
+        url: `${this.serverUrl}${PATH_VOICES}`,
+        method: "GET",
+        throw: false,
+      });
+
+      if (res.status === 200) {
+        const voices = parseVoicesResponse(res.json);
+
+        return { isValid: true, voiceCount: voices.length, voices };
+      }
+
+      return {
+        isValid: false,
+        error: `Piper server returned HTTP ${res.status}. Is it running correctly?`,
+      };
+    } catch {
+      return {
+        isValid: false,
+        error: `Cannot reach Piper server at ${this.serverUrl}. Make sure it is running (python3 -m piper.http_server -m <voice>).`,
+      };
+    }
+  }
+
+  /**
+   * Synthesize and play plain text via Piper.
+   */
+  async speak(
+    content: string,
+    speed?: number,
+    filePath?: string,
+  ): Promise<void> {
+    if (this.isLoading) {
+      throw new Error("Piper call already in progress.");
+    }
+
+    const text = content.trim();
+    if (!text) {
+      return;
+    }
+
+    this.isLoading = true;
+    try {
+      this.reportProgress(0, 1);
+
+      const chunks = chunkPlainText(text, MAX_CHUNK_CHARS);
+      const audioBlobs: Blob[] = [];
+
+      for (let i = 0; i < chunks.length; i++) {
+        if (this.abortController?.signal.aborted) {
+          throw new Error("AbortError");
+        }
+
+        const blob = await this.synthesizeChunk(chunks[i], speed);
+
+        if (this.abortController?.signal.aborted) {
+          throw new Error("AbortError");
+        }
+
+        audioBlobs.push(blob);
+        this.reportProgress(((i + 1) / chunks.length) * 0.95, 1);
+      }
+
+      const finalBlob = new Blob(audioBlobs, { type: "audio/wav" });
+      this.playBlob(finalBlob, speed, filePath);
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        return;
+      }
+      console.error("Error in Piper speak:", error);
+      this.reportError(error);
+      throw error;
+    } finally {
+      this.isLoading = false;
+      this.abortController = undefined;
+    }
+  }
+
+  /**
+   * POST a single text chunk and return the WAV blob.
+   * Tries /synthesize first (OHF-Voice/piper1-gpl); falls back to POST / on 404
+   * (legacy rhasspy/piper v1.0.0). The detected path is cached for the session.
+   */
+  private async synthesizeChunk(text: string, speed?: number): Promise<Blob> {
+    const effectiveSpeed = speed ?? this.speed;
+    // Piper's length_scale is the inverse of the plugin's speed multiplier:
+    //   plugin 2x (fast) -> length_scale 0.5
+    //   plugin 0.5x (slow) -> length_scale 2.0
+    const lengthScale = effectiveSpeed > 0 ? 1 / effectiveSpeed : 1;
+
+    const body: Record<string, unknown> = {
+      text,
+      length_scale: lengthScale,
+    };
+    if (this.voice) {
+      body["voice"] = this.voice;
+    }
+
+    const path = this.synthesisPath ?? PATH_SYNTHESIZE;
+    const res = await requestUrl({
+      url: `${this.serverUrl}${path}`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      throw: false,
+    });
+
+    // Legacy rhasspy/piper uses POST / instead of POST /synthesize.
+    // Detect once and cache so all subsequent chunks skip the retry.
+    if (
+      res.status === 404 &&
+      path === PATH_SYNTHESIZE &&
+      this.synthesisPath === null
+    ) {
+      this.synthesisPath = PATH_ROOT;
+      return this.synthesizeChunk(text, speed);
+    }
+
+    if (this.synthesisPath === null) {
+      this.synthesisPath = PATH_SYNTHESIZE;
+    }
+
+    if (res.status !== 200) {
+      throw new Error(`Piper synthesis failed (HTTP ${res.status})`);
+    }
+
+    const buf = res.arrayBuffer;
+    if (!buf || buf.byteLength === 0) {
+      throw new Error("Piper returned an empty audio response");
+    }
+
+    return new Blob([buf], { type: "audio/wav" });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Strip trailing slash so URL + path concatenation is always consistent. */
+function normalizeUrl(url: string | undefined): string {
+  return (url || PIPER_DEFAULT_URL).replace(/\/+$/, "");
+}
+
+/**
+ * Parse the GET /voices response into VoiceOption[].
+ *
+ * Both server generations return an object keyed by voice name:
+ *   { "en_US-lessac-medium": { language: { code, name_english, ... }, ... } }
+ *
+ * (The original documentation described an array, but the actual server
+ * implementation uses a dict - verified from the Flask source.)
+ */
+function parseVoicesResponse(json: unknown): VoiceOption[] {
+  if (!json || typeof json !== "object" || Array.isArray(json)) {
+    return [];
+  }
+  return Object.entries(json as Record<string, PiperVoiceConfig>).map(
+    ([name, config]) => {
+      const lang =
+        config?.language?.name_english ?? config?.language?.code ?? "";
+      return {
+        id: name,
+        label: lang ? `${name} (${lang})` : name,
+        lang: config?.language?.code ?? "und",
+        group: config?.language?.name_english ?? config?.language?.code,
+      };
+    },
+  );
+}
+
+/** Partial shape of a voice config value from GET /voices. */
+interface PiperVoiceConfig {
+  language?: {
+    code?: string;
+    name_english?: string;
+  };
+}

--- a/src/service/SpeechProvider.ts
+++ b/src/service/SpeechProvider.ts
@@ -37,6 +37,12 @@ export interface SpeechProvider {
   readonly inputFormat: "ssml" | "text";
 
   /**
+   * Controls whether the text pipeline emits pause
+   * tags or falls back to newline-separated plain text.
+   */
+  readonly supportsBreakTags: boolean;
+
+  /**
    * Synthesize and play the given processed content.
    */
   speak(content: string, speed?: number, filePath?: string): Promise<void>;

--- a/src/service/SpeechProviderFactory.ts
+++ b/src/service/SpeechProviderFactory.ts
@@ -50,6 +50,7 @@ export function createSpeechProvider(settings: VoiceSettings): SpeechProvider {
       settings.PIPER_URL,
       settings.PIPER_VOICE,
       Number(settings.SPEED),
+      settings.piperVoiceCatalog,
     );
   } else {
     provider = new AwsPollyService(

--- a/src/service/SpeechProviderFactory.ts
+++ b/src/service/SpeechProviderFactory.ts
@@ -9,6 +9,7 @@ import { ElevenLabsService } from "./ElevenLabsService";
 import { GoogleTtsService } from "./GoogleTtsService";
 import { AzureSpeechService } from "./AzureSpeechService";
 import { OpenAiSpeechService } from "./OpenAiSpeechService";
+import { PiperService } from "./PiperService";
 
 /**
  * Create the speech provider selected in settings.
@@ -42,6 +43,12 @@ export function createSpeechProvider(settings: VoiceSettings): SpeechProvider {
       settings.OPENAI_API_KEY,
       settings.OPENAI_VOICE,
       settings.OPENAI_MODEL,
+      Number(settings.SPEED),
+    );
+  } else if (settings.TTS_PROVIDER === "piper") {
+    provider = new PiperService(
+      settings.PIPER_URL,
+      settings.PIPER_VOICE,
       Number(settings.SPEED),
     );
   } else {

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -6,6 +6,7 @@ import {
   OPENAI_MODELS,
   MIN_SKIP_SECONDS,
   MAX_SKIP_SECONDS,
+  PIPER_DEFAULT_URL,
 } from "./VoiceSettings";
 import { createSpeechProvider } from "../service/SpeechProviderFactory";
 
@@ -64,6 +65,7 @@ export class VoiceSettingTab extends PluginSettingTab {
           .addOption("google", "Google Cloud")
           .addOption("azure", "Azure Speech")
           .addOption("openai", "OpenAI")
+          .addOption("piper", "Piper (local)")
           .setValue(this.plugin.settings.TTS_PROVIDER)
           .onChange(async (value) => {
             this.plugin.settings.TTS_PROVIDER = value as
@@ -71,7 +73,8 @@ export class VoiceSettingTab extends PluginSettingTab {
               | "elevenlabs"
               | "google"
               | "azure"
-              | "openai";
+              | "openai"
+              | "piper";
             await this.plugin.saveSettings();
             // Swap the active provider and rewire the UI/orchestration
             this.plugin.reinitializeProvider();
@@ -190,9 +193,57 @@ export class VoiceSettingTab extends PluginSettingTab {
       this.displayAzureSettings(containerEl);
     } else if (this.plugin.settings.TTS_PROVIDER === "openai") {
       this.displayOpenAISettings(containerEl);
+    } else if (this.plugin.settings.TTS_PROVIDER === "piper") {
+      this.displayPiperSettings(containerEl);
     } else {
       this.displayPollySettings(containerEl);
     }
+  }
+
+  private displayPiperSettings(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("Piper (local)").setHeading();
+
+    new Setting(containerEl)
+      .setName("Server URL")
+      .setDesc("URL of the running Piper HTTP server.")
+      .addText((text) =>
+        text
+          .setPlaceholder(PIPER_DEFAULT_URL)
+          .setValue(this.plugin.settings.PIPER_URL)
+          .onChange(async (value) => {
+            this.plugin.settings.PIPER_URL = value;
+            await this.plugin.saveSettings();
+            this.plugin.reinitializeProviderCredentials();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Voice")
+      .setDesc(
+        'Model name to request from the server, e.g. "en_US-lessac-medium". Leave blank to use the server\'s loaded default.',
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder("en_US-lessac-medium")
+          .setValue(this.plugin.settings.PIPER_VOICE)
+          .onChange(async (value) => {
+            this.plugin.settings.PIPER_VOICE = value;
+            await this.plugin.saveSettings();
+            this.plugin.reinitializeProviderCredentials();
+          }),
+      );
+
+    this.renderCredentialValidation(containerEl, {
+      providerName: "Piper",
+      isConfigured: () => !!this.plugin.settings.PIPER_URL,
+      missingMessage: "Please enter the Piper server URL before testing.",
+      promptMessage: `Enter the server URL above (default: ${PIPER_DEFAULT_URL}), then click "Test Connection" to verify`,
+      helpText: "New to Piper? ",
+      helpUrl:
+        "https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/API_HTTP.md",
+      sectionTitle: "Connection Test",
+      testButtonLabel: "Test Connection",
+    });
   }
 
   private displayOpenAISettings(containerEl: HTMLElement): void {
@@ -494,6 +545,8 @@ export class VoiceSettingTab extends PluginSettingTab {
       promptMessage: string;
       helpText: string;
       helpUrl: string;
+      sectionTitle?: string;
+      testButtonLabel?: string;
     },
   ): void {
     const validationContainer = containerEl.createDiv({
@@ -506,12 +559,13 @@ export class VoiceSettingTab extends PluginSettingTab {
 
     headerRow.createDiv({
       cls: "voice-validation-title",
-      text: "Credential Validation",
+      text: opts.sectionTitle ?? "Credential Validation",
     });
 
+    const buttonLabel = opts.testButtonLabel ?? "Test Credentials";
     const testButton = headerRow.createEl("button", {
       cls: "voice-validation-test-button",
-      text: "Test Credentials",
+      text: buttonLabel,
     });
 
     const statusContainer = validationContainer.createDiv({
@@ -565,13 +619,13 @@ export class VoiceSettingTab extends PluginSettingTab {
       }
 
       testButton.disabled = false;
-      testButton.textContent = "Test Credentials";
+      testButton.textContent = buttonLabel;
 
       if (isValid === true) {
         statusIndicator.addClass("is-valid");
         statusText.addClass("is-valid");
         statusText.textContent = voiceCount
-          ? `✓ Credentials valid! Found ${voiceCount} voices available.`
+          ? `✓ Credentials valid! Found ${voiceCount} voice(s) available.`
           : "✓ Credentials are valid!";
         helpContainer.removeClass("is-visible");
       } else if (isValid === false) {
@@ -599,17 +653,20 @@ export class VoiceSettingTab extends PluginSettingTab {
         const result = await tempProvider.validateCredentials();
 
         if (result.isValid) {
-          // Cache a freshly fetched voice catalog (Azure) so the picker can
-          // offer every voice grouped by language, then resync the player.
-          if (
-            result.voices &&
-            result.voices.length > 0 &&
-            this.plugin.settings.TTS_PROVIDER === "azure"
-          ) {
-            this.plugin.settings.azureVoiceCatalog = result.voices;
-            await this.plugin.saveSettings();
-            this.plugin.reinitializeProviderCredentials();
-            this.plugin.refreshVoicePlayerControls();
+          // Cache a freshly fetched voice catalog (Azure, Piper) so the picker
+          // can offer every voice grouped by language, then resync the player.
+          if (result.voices && result.voices.length > 0) {
+            if (this.plugin.settings.TTS_PROVIDER === "azure") {
+              this.plugin.settings.azureVoiceCatalog = result.voices;
+              await this.plugin.saveSettings();
+              this.plugin.reinitializeProviderCredentials();
+              this.plugin.refreshVoicePlayerControls();
+            } else if (this.plugin.settings.TTS_PROVIDER === "piper") {
+              this.plugin.settings.piperVoiceCatalog = result.voices;
+              await this.plugin.saveSettings();
+              this.plugin.reinitializeProviderCredentials();
+              this.plugin.refreshVoicePlayerControls();
+            }
           }
           updateStatus(true, "", false, result.voiceCount);
         } else {

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -6,7 +6,8 @@ export type TtsProvider =
   | "elevenlabs"
   | "google"
   | "azure"
-  | "openai";
+  | "openai"
+  | "piper";
 
 /**
  * Where saved MP3s are written.
@@ -51,6 +52,14 @@ export interface VoiceSettings {
   OPENAI_API_KEY: string;
   OPENAI_VOICE: string;
   OPENAI_MODEL: string;
+
+  // Piper (local TTS server)
+  PIPER_URL: string;   // default: see PIPER_DEFAULT_URL
+  PIPER_VOICE: string; // model name, e.g. "en_US-lessac-medium"; empty = server default
+  // Piper: voice catalog fetched from /voices on "Test Connection", cached so
+  // the player can show available voices grouped by language. Empty/undefined
+  // until the user validates the connection.
+  piperVoiceCatalog?: VoiceOption[];
 
   // Content / speech options (shared across providers)
   spellOutAcronyms: boolean;
@@ -99,6 +108,9 @@ export interface VoiceSettings {
  * Bounds and default for the rewind/fast-forward skip interval (seconds)
  */
 export const MIN_SKIP_SECONDS = 1;
+
+/** Default URL for the Piper HTTP server. */
+export const PIPER_DEFAULT_URL = "http://localhost:5000";
 export const MAX_SKIP_SECONDS = 60;
 export const DEFAULT_SKIP_SECONDS = 3;
 
@@ -370,6 +382,9 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   OPENAI_API_KEY: "",
   OPENAI_VOICE: "alloy",
   OPENAI_MODEL: "gpt-4o-mini-tts",
+
+  PIPER_URL: PIPER_DEFAULT_URL,
+  PIPER_VOICE: "",
 
   spellOutAcronyms: false,
   readCodeBlocks: false,

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -34,6 +34,7 @@ const PROVIDERS: { id: TtsProvider; label: string }[] = [
   { id: "google", label: "Google Cloud" },
   { id: "azure", label: "Azure Speech" },
   { id: "openai", label: "OpenAI" },
+  { id: "piper", label: "Piper (local)" },
 ];
 
 /**

--- a/src/utils/AudioFileManager.ts
+++ b/src/utils/AudioFileManager.ts
@@ -46,8 +46,15 @@ export class AudioFileManager {
       const dir = this.resolveSaveDir(params.folder, "");
       await this.ensureFolderExists(dir);
 
+      // Derive extension from the blob MIME type for saves, or from the
+      // existing file for moves (WAV from Piper, MP3 from cloud providers).
+      const ext =
+        params.kind === "move"
+          ? (params.sourceFile?.extension ?? "mp3")
+          : blobExtension(params.blob);
+
       const pathFor = (base: string): string =>
-        normalizePath(dir ? `${dir}/${base}.mp3` : `${base}.mp3`);
+        normalizePath(dir ? `${dir}/${base}.${ext}` : `${base}.${ext}`);
       const sourcePath = params.sourceFile?.path;
 
       // Resolve same-name conflicts (a rename can still collide, so loop).
@@ -62,11 +69,11 @@ export class AudioFileManager {
           break;
         }
         const choice = await params.resolveConflict({
-          fileName: `${baseName}.mp3`,
+          fileName: `${baseName}.${ext}`,
           folder: dir === "" ? "the vault root" : dir,
           suggested: suggestFreeBaseName(
             baseName,
-            this.mp3BaseNamesInFolder(dir),
+            this.audioBaseNamesInFolder(dir, ext),
           ),
         });
         if (choice.action === "cancel") {
@@ -88,7 +95,7 @@ export class AudioFileManager {
 
       await this.writeBlob(params.blob, finalPath);
       if (params.embed) {
-        await this.insertAudioEmbed(`${baseName}.mp3`);
+        await this.insertAudioEmbed(`${baseName}.${ext}`);
       }
     } catch (error) {
       console.error("Error saving/moving audio:", error);
@@ -135,14 +142,14 @@ export class AudioFileManager {
     }
   }
 
-  /** Base names (no extension) of the MP3s already in a vault folder. */
-  private mp3BaseNamesInFolder(dir: string): string[] {
+  /** Base names (no extension) of audio files with the given extension already in a vault folder. */
+  private audioBaseNamesInFolder(dir: string, ext: string): string[] {
     const target = normalizeFolderPath(dir === "" ? "/" : dir);
     return this.app.vault
       .getFiles()
       .filter(
         (f) =>
-          f.extension === "mp3" &&
+          f.extension === ext &&
           normalizeFolderPath(f.parent?.path ?? "/") === target,
       )
       .map((f) => f.basename);
@@ -167,13 +174,14 @@ export class AudioFileManager {
         return null;
       }
 
-      // Construct MP3 filename based on active file
+      // Construct audio filename based on active file
       const fileName = activeFile.basename;
       const fileDir = this.resolveSaveDir(
         targetFolder,
         activeFile.parent?.path || "",
       );
-      const audioFileName = `${fileName}.mp3`;
+      const ext = blobExtension(audioBlob);
+      const audioFileName = `${fileName}.${ext}`;
       const audioFilePath = normalizePath(
         fileDir ? `${fileDir}/${audioFileName}` : audioFileName,
       );
@@ -328,7 +336,7 @@ export class AudioFileManager {
       }
 
       const fileName = activeFile.basename;
-      const audioFileName = `${fileName}.mp3`;
+      const audioFileName = `${fileName}.${blobExtension(audioBlob)}`;
 
       // Save the audio file
       const savedFile = await this.saveAudioFile(audioBlob, targetFolder);
@@ -345,4 +353,12 @@ export class AudioFileManager {
       new Notice(`Error downloading audio: ${error.message}`);
     }
   }
+}
+
+/**
+ * Derive a file extension from a Blob's MIME type.
+ * Returns "wav" for WAV audio (Piper), "mp3" for everything else.
+ */
+function blobExtension(blob: Blob | undefined): string {
+  return blob?.type === "audio/wav" ? "wav" : "mp3";
 }

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -62,10 +62,13 @@ export class TextSpeaker {
     // Plain-text pipeline (ElevenLabs and other non-SSML providers). It also
     // needs the acronym setting so it can title-case acronyms when spell-out is
     // off, keeping pronunciation consistent with the SSML providers.
-    this.textProcessor = new MarkdownToTextProcessor({
-      ...contentOptions,
-      spellOutAcronyms: this.spellOutAcronyms,
-    });
+    this.textProcessor = new MarkdownToTextProcessor(
+      {
+        ...contentOptions,
+        spellOutAcronyms: this.spellOutAcronyms,
+      },
+      { pauseTags: provider.supportsBreakTags },
+    );
   }
 
   async speakText(speed?: number): Promise<void> {

--- a/tests/piper.unit.test.ts
+++ b/tests/piper.unit.test.ts
@@ -1,0 +1,316 @@
+import { requestUrl } from "obsidian";
+import { PiperService } from "../src/service/PiperService";
+import { createSpeechProvider } from "../src/service/SpeechProviderFactory";
+import { DEFAULT_SETTINGS } from "../src/settings/VoiceSettings";
+
+const mockRequestUrl = requestUrl as jest.Mock;
+
+describe("Unit Tests - Piper Provider", () => {
+  beforeEach(() => {
+    mockRequestUrl.mockReset();
+  });
+
+  describe("Provider basics", () => {
+    test("declares the plain-text input format", () => {
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      expect(service.inputFormat).toBe("text");
+    });
+
+    test("returns an empty voice catalog before any server fetch", () => {
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      expect(service.getVoiceOptions()).toEqual([]);
+    });
+
+    test("strips trailing slash from the server URL", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(32),
+      });
+      const service = new PiperService("http://localhost:5000/", "", 1.0);
+      await service.speak("hi", 1.0, "note.md");
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.url).toBe("http://localhost:5000/synthesize");
+    });
+
+    test("defaults to http://localhost:5000 when URL is empty", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(32),
+      });
+      const service = new PiperService("", "", 1.0);
+      await service.speak("hi", 1.0, "note.md");
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.url).toContain("http://localhost:5000");
+    });
+  });
+
+  describe("Speed (length_scale) mapping", () => {
+    const synthesizeAndGetLengthScale = async (
+      speed: number,
+    ): Promise<number> => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(32),
+      });
+      const service = new PiperService("http://localhost:5000", "", speed);
+      await service.speak("test", speed, "note.md");
+      const body = JSON.parse(mockRequestUrl.mock.calls[0][0].body);
+      return body.length_scale as number;
+    };
+
+    test("normal speed 1x -> length_scale 1.0", async () => {
+      expect(await synthesizeAndGetLengthScale(1.0)).toBeCloseTo(1.0);
+    });
+
+    test("fast speed 2x -> length_scale 0.5", async () => {
+      expect(await synthesizeAndGetLengthScale(2.0)).toBeCloseTo(0.5);
+    });
+
+    test("slow speed 0.5x -> length_scale 2.0", async () => {
+      expect(await synthesizeAndGetLengthScale(0.5)).toBeCloseTo(2.0);
+    });
+  });
+
+  describe("Synthesis", () => {
+    test("POSTs to /synthesize with text and length_scale", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(64),
+      });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      await service.speak("Hello world.", 1.0, "note.md");
+
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.url).toBe("http://localhost:5000/synthesize");
+      expect(call.method).toBe("POST");
+      expect(call.headers["Content-Type"]).toBe("application/json");
+
+      const body = JSON.parse(call.body);
+      expect(body.text).toBe("Hello world.");
+      expect(body.length_scale).toBeCloseTo(1.0);
+    });
+
+    test("falls back to POST / on 404 (legacy rhasspy/piper)", async () => {
+      // First call to /synthesize returns 404; second to / returns audio.
+      mockRequestUrl
+        .mockResolvedValueOnce({ status: 404 })
+        .mockResolvedValue({ status: 200, arrayBuffer: new ArrayBuffer(32) });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      await service.speak("Hello.", 1.0, "note.md");
+
+      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+      const fallbackCall = mockRequestUrl.mock.calls[1][0];
+      expect(fallbackCall.url).toBe("http://localhost:5000/");
+    });
+
+    test("uses cached path / on subsequent calls after fallback detection", async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce({ status: 404 }) // /synthesize probe
+        .mockResolvedValue({ status: 200, arrayBuffer: new ArrayBuffer(32) }); // / onwards
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      await service.speak("First.");
+      await service.speak("Second.");
+
+      const urls = mockRequestUrl.mock.calls.map((c) => c[0].url);
+      // Call 0: /synthesize (probe), Call 1: / (retry), Call 2: / (second speak, no retry)
+      expect(urls[0]).toContain("/synthesize");
+      expect(urls[1]).toBe("http://localhost:5000/");
+      expect(urls[2]).toBe("http://localhost:5000/");
+    });
+
+    test("includes the voice name when set", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(32),
+      });
+
+      const service = new PiperService(
+        "http://localhost:5000",
+        "en_US-lessac-medium",
+        1.0,
+      );
+      await service.speak("Hello.", 1.0, "note.md");
+
+      const body = JSON.parse(mockRequestUrl.mock.calls[0][0].body);
+      expect(body.voice).toBe("en_US-lessac-medium");
+    });
+
+    test("omits the voice field when voice is empty", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(32),
+      });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      await service.speak("Hello.", 1.0, "note.md");
+
+      const body = JSON.parse(mockRequestUrl.mock.calls[0][0].body);
+      expect(body.voice).toBeUndefined();
+    });
+
+    test("caches the audio blob for download after synthesis", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(64),
+      });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      await service.speak("Hello world.", 1.0, "note.md");
+
+      expect(service.getLastGeneratedAudio("note.md")).not.toBeNull();
+    });
+
+    test("chunks long text into multiple requests", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(16),
+      });
+
+      // Three paragraphs of ~2000 chars each -> exceeds the 3000 char chunk size
+      const paragraph = "word ".repeat(400).trim();
+      const longText = [paragraph, paragraph, paragraph].join("\n\n");
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      await service.speak(longText);
+
+      expect(mockRequestUrl.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    test("throws and reports an error on HTTP 500", async () => {
+      mockRequestUrl.mockResolvedValue({ status: 500, arrayBuffer: null });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      const errorCallback = jest.fn();
+      service.setErrorCallback(errorCallback);
+
+      await expect(service.speak("Hello")).rejects.toThrow(/HTTP 500/);
+      expect(errorCallback).toHaveBeenCalled();
+    });
+
+    test("throws and reports an error on empty audio response", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(0),
+      });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      const errorCallback = jest.fn();
+      service.setErrorCallback(errorCallback);
+
+      await expect(service.speak("Hello")).rejects.toThrow(/empty/i);
+      expect(errorCallback).toHaveBeenCalled();
+    });
+  });
+
+  describe("Credential / connection validation", () => {
+    test("returns isValid true with voice list on HTTP 200", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        // Server returns a dict keyed by voice name (not an array)
+        json: {
+          "en_US-lessac-medium": {
+            language: {
+              code: "en-US",
+              name_english: "English (United States)",
+            },
+          },
+          "de_DE-thorsten-medium": {
+            language: { code: "de-DE", name_english: "German" },
+          },
+        },
+      });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      const result = await service.validateCredentials();
+
+      expect(result.isValid).toBe(true);
+      expect(result.voiceCount).toBe(2);
+      expect(result.voices).toHaveLength(2);
+      expect(result.voices![0].id).toBe("en_US-lessac-medium");
+      expect(result.voices![0].lang).toBe("en-US");
+    });
+
+    test("handles empty dict from /voices", async () => {
+      mockRequestUrl.mockResolvedValue({ status: 200, json: {} });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      const result = await service.validateCredentials();
+
+      expect(result.isValid).toBe(true);
+      expect(result.voiceCount).toBe(0);
+      expect(result.voices).toHaveLength(0);
+    });
+
+    test("returns isValid false on HTTP 500", async () => {
+      mockRequestUrl.mockResolvedValue({ status: 500 });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      const result = await service.validateCredentials();
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toMatch(/HTTP 500/);
+    });
+
+    test("returns isValid false when the server is unreachable", async () => {
+      mockRequestUrl.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      const result = await service.validateCredentials();
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toMatch(/Cannot reach/i);
+    });
+
+    test("handles non-object /voices response gracefully", async () => {
+      mockRequestUrl.mockResolvedValue({ status: 200, json: null });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      const result = await service.validateCredentials();
+
+      expect(result.isValid).toBe(true);
+      expect(result.voiceCount).toBe(0);
+      expect(result.voices).toHaveLength(0);
+    });
+  });
+
+  describe("updateCredentials", () => {
+    test("updates the server URL and voice from settings", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(32),
+      });
+
+      const service = new PiperService("http://localhost:5000", "", 1.0);
+      service.updateCredentials({
+        ...DEFAULT_SETTINGS,
+        TTS_PROVIDER: "piper",
+        PIPER_URL: "http://192.168.1.10:5000",
+        PIPER_VOICE: "en_US-lessac-medium",
+      });
+      await service.speak("hi", 1.0, "note.md");
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.url).toContain("192.168.1.10:5000");
+      const body = JSON.parse(call.body);
+      expect(body.voice).toBe("en_US-lessac-medium");
+    });
+  });
+});
+
+describe("Unit Tests - Speech Provider Factory (Piper)", () => {
+  test("creates a text-format provider for Piper", () => {
+    const provider = createSpeechProvider({
+      ...DEFAULT_SETTINGS,
+      TTS_PROVIDER: "piper",
+      PIPER_URL: "http://localhost:5000",
+      PIPER_VOICE: "",
+    });
+    expect(provider.inputFormat).toBe("text");
+  });
+});


### PR DESCRIPTION
## Summary

Adds **Piper (local)** as a sixth TTS provider, backed by the open-source [Piper TTS](https://github.com/OHF-Voice/piper1-gpl) neural speech engine. Users self-host a Piper HTTP server and point the plugin at it - no cloud credentials required. Auto-detects legacy vs. current server API versions, saves audio as `.wav`, and suppresses SSML break tags that Piper would otherwise read aloud literally.

## Type of change

- [ ] fix — bug fix (patch)
- [x] feat — new feature (minor)
- [ ] docs — documentation only
- [ ] refactor / chore — no user-facing change
- [ ] BREAKING CHANGE (explain below)

## Changes

- **PiperService.ts** *(new)* — Piper provider. Synthesizes via `POST /synthesize` (OHF-Voice/piper1-gpl v1.4+) with automatic fallback to `POST /` for legacy rhasspy/piper v1.0.0. Returns WAV audio. Speed mapped via `length_scale` (inverse: 2× speed → 0.5 scale). Voice list fetched from `GET /voices`. `synthesisPath` cached after first successful detection.
- **VoiceSettings.ts** — Added `"piper"` to `TtsProvider`; `PIPER_URL`, `PIPER_VOICE`, `piperVoiceCatalog` settings fields; exported `PIPER_DEFAULT_URL` constant (`http://localhost:5000`).
- **VoiceSettingTab.ts** — Piper settings section: server URL, voice name (free text), and a "Test Connection" panel that fetches and caches the voice catalog.
- **SpeechProviderFactory.ts** — Piper branch; passes `piperVoiceCatalog` through to the service (same pattern as Azure).
- **SpeechProvider.ts** / **`BaseSpeechService.ts`** — Added `supportsBreakTags: boolean` (defaults `true`). Set to `false` on `PiperService` to prevent `<break time="Xs"/>` SSML tags from being read aloud literally by the local engine.
- **TextSpeaker.ts** — Passes `{ pauseTags: provider.supportsBreakTags }` into `MarkdownToTextProcessor`, suppressing break-tag emission for providers that don't understand them.
- **AudioFileManager.ts** — Dynamic `.wav`/`.mp3` extension derived from blob MIME type (`audio/wav` → `.wav`, otherwise `.mp3`), so Piper audio saves with the correct extension and embeds correctly.
- **VoicePlayerView.ts** — Added `{ id: "piper", label: "Piper (local)" }` to the `PROVIDERS` constant so the player's provider dropdown renders correctly.
- **piper.unit.test.ts** *(new)* — 24 unit tests: synthesis POST body, speed mapping, endpoint auto-detection and path caching, voice field omission when blank, audio caching, chunking, error handling, `validateCredentials` (dict format / empty / HTTP 500 / ECONNREFUSED), `updateCredentials`, factory construction.
- **`docs/piper-integration.md`** *(new)* — Integration assessment document.

## Provider impact

- [ ] None — no provider-specific behaviour changed
- [ ] AWS Polly
- [ ] ElevenLabs
- [ ] OpenAI
- [ ] Google Cloud
- [ ] Azure Speech

> All existing providers inherit `supportsBreakTags = true` from `BaseSpeechService`, preserving their current behaviour. Piper is a new addition and is not listed above.

## Platform impact

- [x] Desktop
- [x] Mobile (iOS / Android)

> `PiperService` uses `requestUrl` (Obsidian-compatible on all platforms). Mobile requires the Piper HTTP server to be reachable from the device (e.g. on the same network).

## How to test

1. Install and start a Piper HTTP server (e.g. `docker run -p 5000:5000 ...` or the rhasspy/piper binary with `--http`).
    - NOTE: If I've set everything up correctly, you should be able to run this and have a server Just Work™: `docker run --name piper -p 5000:5000 -e PIPER_VOICES="en_US-lessac-medium en_US-lessac-high" --rm kieraneglin/piper-tts`
3. In Obsidian settings → Voice → provider, select **Piper (local)**.
4. Enter the server URL (default `http://localhost:5000`) and click **Test Connection** — expect "✓ Credentials valid! Found N voice(s)".
5. Optionally enter a voice name (e.g. `en_US-lessac-medium`); leave blank to use the server default.
6. Open a note and press Play — audio should play as expected.
7. Save the audio; confirm the downloaded file has a `.wav` extension and the embed resolves correctly.
8. Switch back to any other provider and confirm its behaviour is unchanged.

## Checklist

- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm run lint:check` passes
- [x] `npm test` passes
- [x] Added/updated tests where it makes sense
- [x] Updated docs (README / TROUBLESHOOTING) if behaviour or settings changed
- [x] PR title follows Conventional Commits (e.g. `fix(player): …`)
- [x] No secrets/credentials committed

## Screenshots / recordings

<img width="295" height="350" alt="Screenshot 2026-07-02 at 1 39 13 PM" src="https://github.com/user-attachments/assets/4c33c847-67c2-461d-9495-ab0d3a0b948f" />

<img width="788" height="374" alt="Screenshot 2026-07-02 at 1 39 02 PM" src="https://github.com/user-attachments/assets/84d00705-3cc5-4a14-af0b-d053d16d0158" />
