### PR TITLE
feat(provider): add Windows native (offline) TTS engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 
 - **A real audiobook player** — open the Voice player, see your notes as chapters, and play, skip, and repeat just like a podcast app.
 - **Bring your own provider** — Voice supports all the major text-to-speech engines (**AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, and **Azure Speech**), so you can listen with whichever one you already use. Every feature works the same on all of them.
+- **Or go fully offline** — **Windows Native** reads your notes with the voices built into Windows. No API key, no account, no internet — everything runs on your PC. (Desktop, Windows only.)
 - **Listen in seconds** — turn any note into lifelike speech straight from the ribbon, a command, or the player.
 - **Designed for every device** — the same experience on desktop, iOS, and Android, with a touch-friendly mobile player and control bar.
 - **Own your audio** — download MP3 files, auto-embed them into your note, and keep an offline archive.
@@ -166,7 +167,7 @@ Configure your provider and credentials in **Settings → Voice**. The settings 
 
 | Setting                         | What it does                                                                                                                                                                                                                                                                              |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Speech Provider**             | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI**. The credential fields below adapt to your choice.                                                                                                                                    |
+| **Speech Provider**             | Choose the engine: **Windows Native** (offline, no key), **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI**. The credential fields below adapt to your choice.                                                                                                 |
 | **Rewind interval**             | How many seconds the rewind control jumps back (1–60s, default 3s).                                                                                                                                                                                                                       |
 | **Fast-forward interval**       | How many seconds the fast-forward control jumps ahead (1–60s, default 3s).                                                                                                                                                                                                                |
 | **Save automatically**          | Automatically save and embed the MP3 after each playback. Off by default.                                                                                                                                                                                                                 |
@@ -230,6 +231,8 @@ Start with the provider you already have — you can switch anytime.
 **Azure Speech** — In the [Azure portal](https://portal.azure.com/), create a **Speech** resource and copy a **Key** and **Region**. In **Settings → Voice**, choose **Azure Speech**, select the matching region, pick a voice, paste the key, and press **Test Credentials**.
 
 **OpenAI** — Create an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys). In **Settings → Voice**, choose **OpenAI**, pick a model and voice, paste the key, and press **Test Credentials**.
+
+**Windows Native (offline)** — No account or key needed. In **Settings → Voice**, choose **Windows Native**, then press **Test Credentials** to scan the voices installed on your PC; pick one in the Voice player. Synthesis runs entirely offline through the Windows speech engine (via `powershell.exe`) and saves as MP3 like every other provider. Add more languages under **Windows Settings → Time & Language → Speech → Manage voices**, then re-scan. Desktop, Windows only.
 
 ## Troubleshooting & Help
 

--- a/src/service/SpeechProviderFactory.ts
+++ b/src/service/SpeechProviderFactory.ts
@@ -9,6 +9,7 @@ import { ElevenLabsService } from "./ElevenLabsService";
 import { GoogleTtsService } from "./GoogleTtsService";
 import { AzureSpeechService } from "./AzureSpeechService";
 import { OpenAiSpeechService } from "./OpenAiSpeechService";
+import { WindowsSpeechService } from "./WindowsSpeechService";
 
 /**
  * Create the speech provider selected in settings.
@@ -43,6 +44,12 @@ export function createSpeechProvider(settings: VoiceSettings): SpeechProvider {
       settings.OPENAI_VOICE,
       settings.OPENAI_MODEL,
       Number(settings.SPEED),
+    );
+  } else if (settings.TTS_PROVIDER === "windows") {
+    provider = new WindowsSpeechService(
+      settings.WINDOWS_VOICE,
+      Number(settings.SPEED),
+      settings.windowsVoiceCatalog,
     );
   } else {
     provider = new AwsPollyService(

--- a/src/service/WindowsSpeechService.ts
+++ b/src/service/WindowsSpeechService.ts
@@ -1,0 +1,581 @@
+/*
+ * This provider is desktop-and-Windows only (gated by isWindowsDesktop). It
+ * intentionally uses Node's child_process/fs/os/path to drive PowerShell, so
+ * the cross-platform "no Node builtins" lint rule does not apply here.
+ */
+/* eslint-disable import/no-nodejs-modules */
+import { spawn } from "child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+/* eslint-enable import/no-nodejs-modules */
+import type { VoiceOption, VoiceSettings } from "../settings/VoiceSettings";
+import { BaseSpeechService } from "./BaseSpeechService";
+import type { CredentialValidationResult } from "./SpeechProvider";
+import { chunkPlainText } from "./textChunker";
+import { WINTTS_SCRIPT } from "./winttsScript";
+
+/**
+ * Windows native (offline) Text-to-Speech.
+ *
+ * Uses the speech engine built into Windows — no API key and no network. Text
+ * is handed to a bundled PowerShell bridge (see winttsScript.ts) that renders
+ * MP3 chunks via `Windows.Media.SpeechSynthesis` (modern "OneCore" voices) or
+ * `System.Speech` (legacy "SAPI" desktop voices) and transcodes them to MP3
+ * through the WinRT `MediaTranscoder` (WAV fallback when a system has no MP3
+ * encoder). Real MP3 output matters because the rest of the plugin saves and
+ * embeds `.mp3` audio.
+ *
+ * Desktop + Windows only: every entry point is gated by {@link isWindowsDesktop}
+ * and reports a clear message elsewhere (mobile, macOS, Linux).
+ *
+ * The provider takes the plain-text pipeline output (which carries literal
+ * `<break time="Xs"/>` pause markers) and rebuilds it into an SSML document, so
+ * the native engine — which understands SSML — honours the pauses instead of
+ * reading the markers aloud.
+ */
+
+// Conservative per-request size. Windows synthesis has no hard input limit, but
+// smaller chunks lower first-audio latency and keep progress reporting smooth.
+const MAX_CHUNK_CHARS = 4000;
+
+// Abort synthesis if PowerShell produces no stdout for this long (a hung engine
+// or a blocked script should not wedge the player forever).
+const STDOUT_INACTIVITY_TIMEOUT_MS = 120_000;
+
+// Private-use sentinel wrapping a pause duration in milliseconds. Break markers
+// are converted to this space-free token *before* chunking, so the chunker
+// never splits a marker or emits its inner spaces as separate words, then back
+// to real SSML <break> tags *after* per-chunk XML escaping.
+const PAUSE_SENTINEL = String.fromCharCode(0xe000);
+
+/** Raw voice record emitted by the PowerShell bridge's `list` mode. */
+interface WindowsRawVoice {
+  engine?: string;
+  name?: string;
+  lang?: string;
+  gender?: string;
+}
+
+/**
+ * True when running in the Obsidian **desktop** app on **Windows**, where
+ * `powershell.exe` and Node's child_process/fs are available.
+ */
+export function isWindowsDesktop(): boolean {
+  return (
+    typeof process !== "undefined" &&
+    process.platform === "win32" &&
+    typeof require === "function"
+  );
+}
+
+/** Absolute path to Windows PowerShell 5.1 (never pwsh 7 — it lacks WinRT). */
+function windowsPowershellExe(): string {
+  const systemRoot = process.env.SystemRoot || "C:\\Windows";
+  return join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+}
+
+/** Temp working directory for the bridge script and per-request audio. */
+function winttsBaseDir(): string {
+  return join(tmpdir(), "obsidian-voice-wintts");
+}
+
+/**
+ * Write the PowerShell bridge to the temp dir (only when missing or changed)
+ * and return its path. The script is embedded in the bundle so the plugin
+ * folder still ships nothing but `main.js`.
+ */
+function ensureWinttsScript(): string {
+  const dir = winttsBaseDir();
+  mkdirSync(dir, { recursive: true });
+  const scriptPath = join(dir, "wintts.ps1");
+  let current: string | null = null;
+  try {
+    current = readFileSync(scriptPath, "utf8");
+  } catch {
+    current = null;
+  }
+  if (current !== WINTTS_SCRIPT) {
+    writeFileSync(scriptPath, WINTTS_SCRIPT, "utf8");
+  }
+  return scriptPath;
+}
+
+/**
+ * Normalize a serializer pause duration ("0.35s", "400ms") to whole
+ * milliseconds for the SSML `<break time>` sent to the Windows engine.
+ */
+export function windowsBreakToMs(duration: string): number {
+  const match = /^(\d+(?:\.\d+)?)(ms|s)$/.exec(duration.trim());
+  if (!match) {
+    return 350;
+  }
+  const value = parseFloat(match[1]);
+  return Math.round(match[2] === "s" ? value * 1000 : value);
+}
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Turn plain-text pipeline output (carrying `<break time="Xs"/>` markers) into
+ * one SSML document per chunk. Markers become space-free sentinels first so the
+ * chunker keeps them intact, then real `<break>` tags after XML-escaping the
+ * spoken text around them.
+ */
+export function buildWindowsSsmlChunks(
+  text: string,
+  lang: string,
+  maxLen: number = MAX_CHUNK_CHARS,
+): string[] {
+  const marked = text.replace(
+    /<break\s+time="([^"]+)"\s*\/>/g,
+    (_m, dur: string) =>
+      `${PAUSE_SENTINEL}${windowsBreakToMs(dur)}${PAUSE_SENTINEL}`,
+  );
+  const sentinelBreak = new RegExp(
+    `${PAUSE_SENTINEL}(\\d+)${PAUSE_SENTINEL}`,
+    "g",
+  );
+  return chunkPlainText(marked, maxLen).map((chunk) => {
+    const body = escapeXml(chunk).replace(
+      sentinelBreak,
+      (_m, ms: string) => `<break time="${ms}ms"/>`,
+    );
+    return (
+      `<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" ` +
+      `xml:lang="${escapeXml(lang)}">${body}</speak>`
+    );
+  });
+}
+
+/**
+ * Map the bridge's raw voice list into the plugin's VoiceOption catalog. Each
+ * voice id is `<engine>|<name>` (e.g. "onecore|Microsoft Hortense") so the
+ * synthesis path knows which engine to use; the label drops the "Microsoft "
+ * prefix and appends the gender when known.
+ */
+export function parseWindowsVoices(raw: unknown): VoiceOption[] {
+  let list: unknown = raw;
+  if (!Array.isArray(list)) {
+    list = list ? [list] : [];
+  }
+  const seen = new Set<string>();
+  const voices: VoiceOption[] = [];
+  for (const entry of list as WindowsRawVoice[]) {
+    const name = entry?.name ? String(entry.name) : "";
+    if (!name) {
+      continue;
+    }
+    const engine = entry.engine === "sapi" ? "sapi" : "onecore";
+    const id = `${engine}|${name}`;
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    const gender =
+      entry.gender && entry.gender !== "NotSet" && entry.gender !== "Neutral"
+        ? ` (${entry.gender})`
+        : "";
+    voices.push({
+      id,
+      label: `${name.replace(/^Microsoft\s+/, "")}${gender}`,
+      lang: entry.lang ? String(entry.lang) : "en-US",
+    });
+  }
+  return voices;
+}
+
+/** Parse a `CHUNK <index> <format> <path>` protocol line, or null. */
+export function parseChunkLine(
+  line: string,
+): { index: number; format: string; path: string } | null {
+  const match = /^CHUNK (\d+) (\w+) (.+)$/.exec(line);
+  if (!match) {
+    return null;
+  }
+  return { index: Number(match[1]), format: match[2], path: match[3] };
+}
+
+/**
+ * Spawn the bridge in Windows PowerShell 5.1 and stream its line protocol to
+ * `onLine`. Resolves on `DONE`; rejects on an `ERROR` line, spawn failure,
+ * unexpected exit, abort, or stdout inactivity.
+ */
+function runWinttsProcess(
+  fileArgs: string[],
+  onLine: (line: string) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      windowsPowershellExe(),
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        ...fileArgs,
+      ],
+      { windowsHide: true },
+    );
+
+    let settled = false;
+    let stdoutBuffer = "";
+    let stderrTail = "";
+    let sawDone = false;
+    let inactivityTimer: number | null = null;
+
+    const finish = (fn: (value?: unknown) => void, value?: unknown): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (inactivityTimer !== null) {
+        window.clearTimeout(inactivityTimer);
+      }
+      signal?.removeEventListener("abort", onAbort);
+      fn(value);
+    };
+
+    const onAbort = (): void => {
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      const abortError = new Error("AbortError");
+      abortError.name = "AbortError";
+      finish(reject as (value?: unknown) => void, abortError);
+    };
+
+    const resetInactivity = (): void => {
+      if (inactivityTimer !== null) {
+        window.clearTimeout(inactivityTimer);
+      }
+      inactivityTimer = window.setTimeout(() => {
+        try {
+          child.kill();
+        } catch {
+          /* already gone */
+        }
+        finish(
+          reject as (value?: unknown) => void,
+          new Error(
+            "Windows speech synthesis timed out (no response from PowerShell).",
+          ),
+        );
+      }, STDOUT_INACTIVITY_TIMEOUT_MS);
+    };
+
+    resetInactivity();
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener("abort", onAbort);
+    }
+
+    child.on("error", (err: Error) => {
+      finish(
+        reject as (value?: unknown) => void,
+        new Error(`Could not start Windows PowerShell: ${err.message}`),
+      );
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderrTail = (stderrTail + String(data)).slice(-2000);
+    });
+
+    child.stdout.on("data", (data: Buffer) => {
+      resetInactivity();
+      stdoutBuffer += String(data);
+      let newlineIndex = stdoutBuffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        const line = stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, "");
+        stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+        newlineIndex = stdoutBuffer.indexOf("\n");
+        if (!line.trim()) {
+          continue;
+        }
+        if (line.startsWith("ERROR")) {
+          try {
+            child.kill();
+          } catch {
+            /* already gone */
+          }
+          finish(
+            reject as (value?: unknown) => void,
+            new Error(
+              line.slice(5).trim() || "Windows speech synthesis failed.",
+            ),
+          );
+          return;
+        }
+        if (line === "DONE") {
+          sawDone = true;
+          finish(resolve);
+          return;
+        }
+        onLine(line);
+      }
+    });
+
+    child.on("close", (code: number | null) => {
+      if (sawDone) {
+        return;
+      }
+      finish(
+        reject as (value?: unknown) => void,
+        new Error(
+          `Windows PowerShell exited unexpectedly (code ${code})` +
+            (stderrTail ? `: ${stderrTail.trim()}` : ""),
+        ),
+      );
+    });
+  });
+}
+
+export class WindowsSpeechService extends BaseSpeechService {
+  readonly inputFormat = "text" as const;
+
+  // The cached voice catalog from the last successful scan, or null to fall
+  // back to a single "system default voice" entry.
+  private dynamicVoices: VoiceOption[] | null;
+
+  constructor(voice: string, speed?: number, voiceCatalog?: VoiceOption[]) {
+    super(voice, speed);
+    this.dynamicVoices =
+      voiceCatalog && voiceCatalog.length > 0 ? voiceCatalog : null;
+  }
+
+  /**
+   * Enumerate the OneCore (modern) and SAPI (legacy desktop) voices installed
+   * on this PC via the bundled PowerShell bridge.
+   */
+  static async listVoices(): Promise<VoiceOption[]> {
+    if (!isWindowsDesktop()) {
+      throw new Error(
+        "Windows native speech is only available in the desktop app on Windows.",
+      );
+    }
+    const scriptPath = ensureWinttsScript();
+    let rawJson: string | null = null;
+    await runWinttsProcess([scriptPath, "-Mode", "list"], (line) => {
+      if (line.startsWith("VOICES ")) {
+        rawJson = line.slice(7);
+      }
+    });
+    if (!rawJson) {
+      throw new Error("The Windows voice scan returned no result.");
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawJson);
+    } catch {
+      throw new Error("The Windows voice scan returned invalid data.");
+    }
+    return parseWindowsVoices(parsed);
+  }
+
+  getVoiceOptions(): VoiceOption[] {
+    if (this.dynamicVoices && this.dynamicVoices.length > 0) {
+      return this.dynamicVoices;
+    }
+    return [{ id: "", label: "System default voice", lang: "en-US" }];
+  }
+
+  updateCredentials(settings: VoiceSettings): void {
+    this.dynamicVoices =
+      settings.windowsVoiceCatalog && settings.windowsVoiceCatalog.length > 0
+        ? settings.windowsVoiceCatalog
+        : null;
+  }
+
+  /** Language of the active voice (for the SSML `xml:lang` attribute). */
+  private langForActiveVoice(): string {
+    const active = this.dynamicVoices?.find((v) => v.id === this.voice);
+    return active?.lang || "en-US";
+  }
+
+  /**
+   * Synthesize and play the note with the built-in Windows speech engine.
+   * Fully offline: the SSML is handed to the PowerShell bridge, which renders
+   * MP3 chunks and reports their paths; the chunks are concatenated into a
+   * single blob and played through the shared audio element.
+   */
+  async speak(
+    content: string,
+    speed?: number,
+    filePath?: string,
+  ): Promise<void> {
+    if (this.isLoading) {
+      throw new Error("Windows speech synthesis already in progress.");
+    }
+    if (!isWindowsDesktop()) {
+      const error = new Error(
+        "Windows native speech is only available in the desktop app on Windows.",
+      );
+      this.reportError(error);
+      throw error;
+    }
+
+    const text = content.trim();
+    if (!text) {
+      return;
+    }
+
+    this.isLoading = true;
+    const requestDir = join(
+      winttsBaseDir(),
+      `req_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+    );
+    try {
+      this.reportProgress(0, 1);
+      const scriptPath = ensureWinttsScript();
+      mkdirSync(requestDir, { recursive: true });
+
+      const chunks = buildWindowsSsmlChunks(text, this.langForActiveVoice());
+      const separatorIndex = this.voice ? this.voice.indexOf("|") : -1;
+      const engine =
+        separatorIndex > 0 ? this.voice.slice(0, separatorIndex) : "onecore";
+      const voiceName =
+        separatorIndex > 0 ? this.voice.slice(separatorIndex + 1) : "";
+
+      const jobPath = join(requestDir, "job.json");
+      writeFileSync(
+        jobPath,
+        JSON.stringify({
+          engine,
+          voice: voiceName,
+          format: "mp3",
+          ssml: true,
+          outDir: requestDir,
+          chunks,
+        }),
+        "utf8",
+      );
+
+      const chunkFiles: { format: string; path: string }[] = [];
+      let received = 0;
+      await runWinttsProcess(
+        [scriptPath, "-Mode", "speak", "-JobFile", jobPath],
+        (line) => {
+          const chunk = parseChunkLine(line);
+          if (!chunk) {
+            return;
+          }
+          chunkFiles[chunk.index] = { format: chunk.format, path: chunk.path };
+          received++;
+          this.reportProgress((received / chunks.length) * 0.9, 1);
+        },
+        this.abortController?.signal,
+      );
+
+      const audioBlobs: BlobPart[] = [];
+      let allMp3 = true;
+      for (let i = 0; i < chunks.length; i++) {
+        const chunkFile = chunkFiles[i];
+        if (!chunkFile) {
+          throw new Error(
+            `Windows speech synthesis produced no audio for part ${i + 1}.`,
+          );
+        }
+        if (chunkFile.format !== "mp3") {
+          allMp3 = false;
+        }
+        const buffer = readFileSync(chunkFile.path);
+        if (!buffer || buffer.byteLength === 0) {
+          throw new Error("Windows speech synthesis returned empty audio.");
+        }
+        audioBlobs.push(
+          new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength),
+        );
+      }
+
+      this.reportProgress(0.95, 1);
+      const finalBlob = new Blob(audioBlobs, {
+        type: allMp3 ? "audio/mpeg" : "audio/wav",
+      });
+      this.playBlob(finalBlob, speed, filePath);
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        return;
+      }
+      console.error("Error in Windows speech speak:", error);
+      this.reportError(error);
+      throw error;
+    } finally {
+      this.isLoading = false;
+      this.abortController = undefined;
+      try {
+        rmSync(requestDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  }
+
+  /**
+   * "Credentials" for the native engine are just a working Windows PowerShell
+   * plus at least one installed voice. Returns the detected voices so the
+   * settings tab can cache the full catalog (mirrors the Azure catalog flow).
+   */
+  async validateCredentials(): Promise<CredentialValidationResult> {
+    if (!isWindowsDesktop()) {
+      return {
+        isValid: false,
+        error:
+          "Windows native speech is only available in the desktop app on Windows.",
+      };
+    }
+    try {
+      const voices = await WindowsSpeechService.listVoices();
+      if (voices.length === 0) {
+        return {
+          isValid: false,
+          error:
+            "No Windows voices found. Add voices under Windows Settings → Time & Language → Speech.",
+        };
+      }
+      return { isValid: true, voiceCount: voices.length, voices };
+    } catch (error) {
+      console.error("Windows voice scan error:", error);
+      return { isValid: false, error: this.getErrorMessage(error) };
+    }
+  }
+
+  protected getErrorMessage(error: unknown): string {
+    if (error && typeof error === "object" && "message" in error) {
+      const message = String((error as { message: string }).message);
+      if (message.includes("Could not start Windows PowerShell")) {
+        return "Could not start Windows PowerShell (powershell.exe), which is required for the native Windows voices.";
+      }
+      if (message.includes("transcode unavailable")) {
+        return "Windows could not encode MP3 audio (the Media Feature Pack may be missing).";
+      }
+      if (message.includes("only available")) {
+        return message;
+      }
+      if (message.includes("timed out")) {
+        return "Windows speech synthesis timed out. Please try again.";
+      }
+      return `Windows speech error: ${message}`;
+    }
+    return "Windows speech error. Please try again.";
+  }
+}

--- a/src/service/winttsScript.ts
+++ b/src/service/winttsScript.ts
@@ -1,0 +1,225 @@
+/**
+ * PowerShell bridge for the Windows native speech provider.
+ *
+ * The plugin ships only `main.js`, so the script is embedded here as a string
+ * constant and written to a temp file at runtime (see WindowsSpeechService).
+ * It must run under **Windows PowerShell 5.1** (`powershell.exe`) — the WinRT
+ * type projection it relies on is not available in PowerShell 7+ (`pwsh`).
+ *
+ * Protocol (one message per line on stdout):
+ *   list mode:   `VOICES <compact-json-array>` then `DONE`
+ *   speak mode:  `CHUNK <index> <format> <path>` per chunk, then `DONE`
+ *   on failure:  `ERROR <message>`
+ *
+ * The script reads a job JSON `{ engine, voice, format, ssml, outDir, chunks[] }`
+ * in speak mode, synthesizes each chunk with either the modern OneCore engine
+ * (`Windows.Media.SpeechSynthesis`) or the legacy SAPI engine
+ * (`System.Speech.Synthesis`), and transcodes the result to MP3 via the WinRT
+ * `MediaTranscoder` (falling back to WAV when no MP3 encoder is present).
+ */
+export const WINTTS_SCRIPT = `# wintts - Windows native TTS bridge for the Obsidian Voice plugin.
+# Runs in Windows PowerShell 5.1 (WinRT projection is unavailable in pwsh 7).
+# Modes:
+#   list           - print "VOICES <json>" with every OneCore + SAPI voice
+#   speak -JobFile - read a job json {engine,voice,format,ssml,outDir,chunks[]},
+#                    synthesize each chunk, print "CHUNK <i> <format> <path>"
+#                    per chunk and "DONE" at the end.
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][ValidateSet('list', 'speak')][string]$Mode,
+  [string]$JobFile
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+
+function Out-Line([string]$s) { [Console]::Out.WriteLine($s); [Console]::Out.Flush() }
+
+try {
+  Add-Type -AssemblyName System.Runtime.WindowsRuntime
+  try { Add-Type -AssemblyName System.Speech } catch {}
+
+  # Force WinRT type projections.
+  $null = [Windows.Media.SpeechSynthesis.SpeechSynthesizer, Windows.Media.SpeechSynthesis, ContentType = WindowsRuntime]
+  $null = [Windows.Media.SpeechSynthesis.SpeechSynthesisStream, Windows.Media.SpeechSynthesis, ContentType = WindowsRuntime]
+  $null = [Windows.Media.Transcoding.MediaTranscoder, Windows.Media.Transcoding, ContentType = WindowsRuntime]
+  $null = [Windows.Media.Transcoding.PrepareTranscodeResult, Windows.Media.Transcoding, ContentType = WindowsRuntime]
+  $null = [Windows.Media.MediaProperties.MediaEncodingProfile, Windows.Media.MediaProperties, ContentType = WindowsRuntime]
+  $null = [Windows.Media.MediaProperties.AudioEncodingQuality, Windows.Media.MediaProperties, ContentType = WindowsRuntime]
+  $null = [Windows.Storage.Streams.InMemoryRandomAccessStream, Windows.Storage.Streams, ContentType = WindowsRuntime]
+  $null = [Windows.Storage.Streams.IRandomAccessStream, Windows.Storage.Streams, ContentType = WindowsRuntime]
+  $null = [Windows.Storage.StorageFile, Windows.Storage, ContentType = WindowsRuntime]
+  $null = [Windows.Storage.FileAccessMode, Windows.Storage, ContentType = WindowsRuntime]
+
+  $script:AsTaskOp = ([System.WindowsRuntimeSystemExtensions].GetMethods() | Where-Object {
+      $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and
+      $_.GetParameters()[0].ParameterType.Name -eq 'IAsyncOperation\`1'
+    })[0]
+  $script:AsTaskActionProgress = ([System.WindowsRuntimeSystemExtensions].GetMethods() | Where-Object {
+      $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and
+      $_.GetParameters()[0].ParameterType.Name -eq 'IAsyncActionWithProgress\`1'
+    })[0]
+
+  function Await($op, $resultType) {
+    $t = $script:AsTaskOp.MakeGenericMethod($resultType).Invoke($null, @($op))
+    $null = $t.Wait(-1)
+    return $t.Result
+  }
+  function AwaitActionWithProgress($op, $progressType) {
+    $t = $script:AsTaskActionProgress.MakeGenericMethod($progressType).Invoke($null, @($op))
+    $null = $t.Wait(-1)
+  }
+
+  function Get-AllVoices {
+    $voices = @()
+    try {
+      foreach ($v in [Windows.Media.SpeechSynthesis.SpeechSynthesizer]::AllVoices) {
+        $voices += @{ engine = 'onecore'; name = $v.DisplayName; lang = $v.Language; gender = $v.Gender.ToString() }
+      }
+    } catch {}
+    try {
+      $s = New-Object System.Speech.Synthesis.SpeechSynthesizer
+      try {
+        foreach ($iv in $s.GetInstalledVoices()) {
+          if (-not $iv.Enabled) { continue }
+          $v = $iv.VoiceInfo
+          $voices += @{ engine = 'sapi'; name = $v.Name; lang = $v.Culture.Name; gender = $v.Gender.ToString() }
+        }
+      } finally { $s.Dispose() }
+    } catch {}
+    return , $voices
+  }
+
+  if ($Mode -eq 'list') {
+    $voices = Get-AllVoices
+    Out-Line ('VOICES ' + (ConvertTo-Json @($voices) -Compress -Depth 4))
+    Out-Line 'DONE'
+    exit 0
+  }
+
+  # ---- speak mode ----
+  if (-not $JobFile -or -not (Test-Path -LiteralPath $JobFile)) {
+    Out-Line 'ERROR job file not found'
+    exit 1
+  }
+  $job = Get-Content -LiteralPath $JobFile -Raw -Encoding UTF8 | ConvertFrom-Json
+  $outDir = [string]$job.outDir
+  $engine = [string]$job.engine
+  $voiceName = [string]$job.voice
+  $wantMp3 = ([string]$job.format -eq 'mp3')
+  $useSsml = $false
+  try { if ($job.ssml) { $useSsml = $true } } catch {}
+  if (-not (Test-Path -LiteralPath $outDir)) {
+    $null = New-Item -ItemType Directory -Force -Path $outDir
+  }
+
+  $script:mp3Profile = $null
+  if ($wantMp3) {
+    try {
+      $script:mp3Profile = [Windows.Media.MediaProperties.MediaEncodingProfile]::CreateMp3([Windows.Media.MediaProperties.AudioEncodingQuality]::Medium)
+    } catch { $script:mp3Profile = $null }
+  }
+
+  function Convert-StreamToMp3File($inStream, [string]$outPath) {
+    $transcoder = New-Object Windows.Media.Transcoding.MediaTranscoder
+    $outStream = New-Object Windows.Storage.Streams.InMemoryRandomAccessStream
+    try {
+      $prep = Await ($transcoder.PrepareStreamTranscodeAsync($inStream, $outStream, $script:mp3Profile)) ([Windows.Media.Transcoding.PrepareTranscodeResult])
+      if (-not $prep.CanTranscode) { throw "transcode unavailable: $($prep.FailureReason)" }
+      AwaitActionWithProgress ($prep.TranscodeAsync()) ([double])
+      $null = $outStream.Seek(0)
+      $net = [System.IO.WindowsRuntimeStreamExtensions]::AsStreamForRead($outStream)
+      $fs = [System.IO.File]::Create($outPath)
+      try { $net.CopyTo($fs) } finally { $fs.Dispose(); $net.Dispose() }
+    } finally { $outStream.Dispose() }
+  }
+
+  function Copy-WinRtStreamToFile($inStream, [string]$outPath) {
+    $null = $inStream.Seek(0)
+    $net = [System.IO.WindowsRuntimeStreamExtensions]::AsStreamForRead($inStream)
+    $fs = [System.IO.File]::Create($outPath)
+    try { $net.CopyTo($fs) } finally { $fs.Dispose(); $net.Dispose() }
+  }
+
+  $chunks = @($job.chunks)
+
+  if ($engine -eq 'sapi') {
+    $sapi = New-Object System.Speech.Synthesis.SpeechSynthesizer
+    try {
+      if ($voiceName) {
+        try { $sapi.SelectVoice($voiceName) } catch {}
+      }
+      for ($i = 0; $i -lt $chunks.Count; $i++) {
+        $wavPath = Join-Path $outDir ("chunk_$i.wav")
+        $sapi.SetOutputToWaveFile($wavPath)
+        if ($useSsml) {
+          $sapi.SpeakSsml([string]$chunks[$i])
+        } else {
+          $sapi.Speak([string]$chunks[$i])
+        }
+        $sapi.SetOutputToNull()
+        $emitted = $wavPath
+        $fmt = 'wav'
+        if ($script:mp3Profile) {
+          try {
+            $inFile = Await ([Windows.Storage.StorageFile]::GetFileFromPathAsync($wavPath)) ([Windows.Storage.StorageFile])
+            $inStream = Await ($inFile.OpenAsync([Windows.Storage.FileAccessMode]::Read)) ([Windows.Storage.Streams.IRandomAccessStream])
+            try {
+              $mp3Path = Join-Path $outDir ("chunk_$i.mp3")
+              Convert-StreamToMp3File $inStream $mp3Path
+              $emitted = $mp3Path
+              $fmt = 'mp3'
+            } finally { $inStream.Dispose() }
+          } catch {}
+        }
+        if ($fmt -eq 'mp3') {
+          try { Remove-Item -LiteralPath $wavPath -Force } catch {}
+        }
+        Out-Line ("CHUNK $i $fmt $emitted")
+      }
+    } finally { $sapi.Dispose() }
+  } else {
+    $synth = New-Object Windows.Media.SpeechSynthesis.SpeechSynthesizer
+    try {
+      if ($voiceName) {
+        $v = [Windows.Media.SpeechSynthesis.SpeechSynthesizer]::AllVoices | Where-Object { $_.DisplayName -eq $voiceName } | Select-Object -First 1
+        if ($v) { $synth.Voice = $v }
+      }
+      for ($i = 0; $i -lt $chunks.Count; $i++) {
+        if ($useSsml) {
+          $stream = Await ($synth.SynthesizeSsmlToStreamAsync([string]$chunks[$i])) ([Windows.Media.SpeechSynthesis.SpeechSynthesisStream])
+        } else {
+          $stream = Await ($synth.SynthesizeTextToStreamAsync([string]$chunks[$i])) ([Windows.Media.SpeechSynthesis.SpeechSynthesisStream])
+        }
+        try {
+          $emitted = $null
+          $fmt = 'wav'
+          if ($script:mp3Profile) {
+            try {
+              $mp3Path = Join-Path $outDir ("chunk_$i.mp3")
+              Convert-StreamToMp3File $stream $mp3Path
+              $emitted = $mp3Path
+              $fmt = 'mp3'
+            } catch { $emitted = $null }
+          }
+          if (-not $emitted) {
+            $wavPath = Join-Path $outDir ("chunk_$i.wav")
+            Copy-WinRtStreamToFile $stream $wavPath
+            $emitted = $wavPath
+            $fmt = 'wav'
+          }
+          Out-Line ("CHUNK $i $fmt $emitted")
+        } finally { $stream.Dispose() }
+      }
+    } finally { $synth.Dispose() }
+  }
+
+  Out-Line 'DONE'
+  exit 0
+} catch {
+  $msg = ($_ | Out-String) -replace "\\r?\\n", ' '
+  Out-Line ("ERROR " + $msg.Trim())
+  exit 1
+}
+`;

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -55,10 +55,11 @@ export class VoiceSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Speech Provider")
       .setDesc(
-        "Choose which text-to-speech engine to use. AWS Polly, ElevenLabs, and Google Cloud offer the same plugin features; each uses its own credentials and voices.",
+        "Choose which text-to-speech engine to use. Windows Native uses the voices built into Windows — fully offline, no API key. AWS Polly, ElevenLabs, and Google Cloud offer the same plugin features; each uses its own credentials and voices.",
       )
       .addDropdown((dropdown) => {
         dropdown
+          .addOption("windows", "Windows Native (offline)")
           .addOption("polly", "AWS Polly")
           .addOption("elevenlabs", "ElevenLabs")
           .addOption("google", "Google Cloud")
@@ -71,7 +72,8 @@ export class VoiceSettingTab extends PluginSettingTab {
               | "elevenlabs"
               | "google"
               | "azure"
-              | "openai";
+              | "openai"
+              | "windows";
             await this.plugin.saveSettings();
             // Swap the active provider and rewire the UI/orchestration
             this.plugin.reinitializeProvider();
@@ -182,7 +184,9 @@ export class VoiceSettingTab extends PluginSettingTab {
       );
 
     // Provider-specific credentials
-    if (this.plugin.settings.TTS_PROVIDER === "elevenlabs") {
+    if (this.plugin.settings.TTS_PROVIDER === "windows") {
+      this.displayWindowsSettings(containerEl);
+    } else if (this.plugin.settings.TTS_PROVIDER === "elevenlabs") {
       this.displayElevenLabsSettings(containerEl);
     } else if (this.plugin.settings.TTS_PROVIDER === "google") {
       this.displayGoogleSettings(containerEl);
@@ -193,6 +197,31 @@ export class VoiceSettingTab extends PluginSettingTab {
     } else {
       this.displayPollySettings(containerEl);
     }
+  }
+
+  private displayWindowsSettings(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("Windows native speech").setHeading();
+
+    const catalog = this.plugin.settings.windowsVoiceCatalog ?? [];
+    new Setting(containerEl)
+      .setName("Voices")
+      .setDesc(
+        catalog.length > 0
+          ? `${catalog.length} voices detected on this PC. Pick the active voice in the Voice player. To add more voices, open Windows Settings → Time & Language → Speech → Manage voices, then re-run the scan below.`
+          : "No voices detected yet. Click 'Test Credentials' below to scan the voices installed on this PC.",
+      );
+
+    this.renderCredentialValidation(containerEl, {
+      providerName: "Windows",
+      isConfigured: () => true,
+      missingMessage: "",
+      promptMessage:
+        "Click 'Test Credentials' to scan the voices installed on this PC",
+      helpText:
+        "Uses the voices built into Windows — no API key and no internet needed. Want more voices? ",
+      helpUrl:
+        "https://support.microsoft.com/en-us/windows/appendix-a-supported-languages-and-voices-4486e345-7730-53da-fcfe-55cc64300f01",
+    });
   }
 
   private displayOpenAISettings(containerEl: HTMLElement): void {
@@ -610,6 +639,17 @@ export class VoiceSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
             this.plugin.reinitializeProviderCredentials();
             this.plugin.refreshVoicePlayerControls();
+          }
+          // Cache the Windows voice scan and pick a sensible default voice.
+          if (
+            result.voices &&
+            result.voices.length > 0 &&
+            this.plugin.settings.TTS_PROVIDER === "windows"
+          ) {
+            await this.plugin.applyWindowsVoiceCatalog(result.voices);
+            // Re-render so the "N voices detected" description updates.
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            this.display();
           }
           updateStatus(true, "", false, result.voiceCount);
         } else {

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -6,7 +6,8 @@ export type TtsProvider =
   | "elevenlabs"
   | "google"
   | "azure"
-  | "openai";
+  | "openai"
+  | "windows";
 
 /**
  * Where saved MP3s are written.
@@ -51,6 +52,15 @@ export interface VoiceSettings {
   OPENAI_API_KEY: string;
   OPENAI_VOICE: string;
   OPENAI_MODEL: string;
+
+  // Windows native (offline) speech
+  // The chosen voice id, encoded as "<engine>|<name>" (e.g.
+  // "onecore|Microsoft Hortense"); empty means the system default voice.
+  WINDOWS_VOICE: string;
+  // The voices detected on this PC, cached from a "Test Credentials" scan so
+  // the picker can offer every installed voice grouped by language. Empty until
+  // the first scan; a single "system default voice" entry is the fallback.
+  windowsVoiceCatalog?: VoiceOption[];
 
   // Content / speech options (shared across providers)
   spellOutAcronyms: boolean;
@@ -370,6 +380,9 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   OPENAI_API_KEY: "",
   OPENAI_VOICE: "alloy",
   OPENAI_MODEL: "gpt-4o-mini-tts",
+
+  WINDOWS_VOICE: "",
+  windowsVoiceCatalog: [],
 
   spellOutAcronyms: false,
   readCodeBlocks: false,

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -29,6 +29,7 @@ type RepeatMode = "none" | "one" | "all";
 
 /** Selectable TTS providers, mirroring the settings tab. */
 const PROVIDERS: { id: TtsProvider; label: string }[] = [
+  { id: "windows", label: "Windows Native" },
   { id: "polly", label: "AWS Polly" },
   { id: "elevenlabs", label: "ElevenLabs" },
   { id: "google", label: "Google Cloud" },

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -3,6 +3,8 @@ import { VoiceSettingTab } from "../settings/VoiceSettingTab";
 import { HotkeySettings } from "../settings/HotkeySettings";
 import type { SpeechProvider } from "../service/SpeechProvider";
 import { createSpeechProvider } from "../service/SpeechProviderFactory";
+import { WindowsSpeechService } from "../service/WindowsSpeechService";
+import type { VoiceOption } from "../settings/VoiceSettings";
 import { Plugin, Platform, Notice } from "obsidian";
 import { MarkdownHelper } from "./MarkdownHelper";
 import { IconEventHandler } from "./IconEventHandler";
@@ -69,6 +71,7 @@ export class Voice extends Plugin {
     this.app.workspace.onLayoutReady(() => {
       void this.placeDefaultPlayerPane();
       this.maybeShowWhatsNew();
+      this.maybeRefreshWindowsVoices();
     });
   }
 
@@ -191,6 +194,62 @@ export class Voice extends Plugin {
     this.speechProvider = createSpeechProvider(this.settings);
     this.iconEventHandler.setProvider(this.speechProvider);
     this.reinitializeTextSpeaker();
+    this.maybeRefreshWindowsVoices();
+  }
+
+  /**
+   * When the Windows provider is active but no voice catalog is cached yet,
+   * scan the installed voices in the background so the picker fills in without
+   * the user having to open settings and press "Test Credentials".
+   */
+  private maybeRefreshWindowsVoices(): void {
+    if (this.settings.TTS_PROVIDER !== "windows") {
+      return;
+    }
+    const catalog = this.settings.windowsVoiceCatalog;
+    if (catalog && catalog.length > 0) {
+      return;
+    }
+    void this.refreshWindowsVoiceCatalog();
+  }
+
+  private async refreshWindowsVoiceCatalog(): Promise<void> {
+    try {
+      const voices = await WindowsSpeechService.listVoices();
+      await this.applyWindowsVoiceCatalog(voices);
+    } catch (error) {
+      console.error("[Voice] Windows voice scan failed:", error);
+    }
+  }
+
+  /**
+   * Persist a freshly scanned Windows voice catalog, defaulting the active
+   * voice to one matching the app locale when the current choice is invalid,
+   * then resync the running provider and any open player panes. Mirrors the
+   * Azure voice-catalog flow.
+   */
+  public async applyWindowsVoiceCatalog(voices: VoiceOption[]): Promise<void> {
+    if (!voices || voices.length === 0) {
+      return;
+    }
+    this.settings.windowsVoiceCatalog = voices;
+
+    let voiceId = this.settings.WINDOWS_VOICE;
+    if (!voiceId || !voices.some((v) => v.id === voiceId)) {
+      const locale = (window.navigator?.language || "en-US").toLowerCase();
+      const prefix = locale.slice(0, 2);
+      const match = voices.find((v) => v.lang.toLowerCase().startsWith(prefix));
+      voiceId = (match ?? voices[0]).id;
+      this.settings.WINDOWS_VOICE = voiceId;
+    }
+    await this.saveSettings();
+
+    if (this.settings.TTS_PROVIDER === "windows") {
+      this.reinitializeProviderCredentials();
+      this.speechProvider.setVoice(voiceId);
+      this.iconEventHandler.updateVoiceDisplay();
+    }
+    this.refreshVoicePlayerControls();
   }
 
   /**
@@ -233,6 +292,8 @@ export class Voice extends Plugin {
       this.settings.AZURE_VOICE = voiceId;
     } else if (this.settings.TTS_PROVIDER === "openai") {
       this.settings.OPENAI_VOICE = voiceId;
+    } else if (this.settings.TTS_PROVIDER === "windows") {
+      this.settings.WINDOWS_VOICE = voiceId;
     } else {
       this.settings.VOICE = voiceId;
     }

--- a/tests/windows-speech.unit.test.ts
+++ b/tests/windows-speech.unit.test.ts
@@ -1,0 +1,175 @@
+import {
+  windowsBreakToMs,
+  buildWindowsSsmlChunks,
+  parseWindowsVoices,
+  parseChunkLine,
+  isWindowsDesktop,
+} from "../src/service/WindowsSpeechService";
+
+describe("Unit Tests - Windows native speech", () => {
+  describe("windowsBreakToMs", () => {
+    test("converts seconds to whole milliseconds", () => {
+      expect(windowsBreakToMs("0.5s")).toBe(500);
+      expect(windowsBreakToMs("2s")).toBe(2000);
+      expect(windowsBreakToMs("0.35s")).toBe(350);
+    });
+
+    test("passes milliseconds through, rounding", () => {
+      expect(windowsBreakToMs("400ms")).toBe(400);
+      expect(windowsBreakToMs("350ms")).toBe(350);
+    });
+
+    test("falls back to 350ms for unparseable input", () => {
+      expect(windowsBreakToMs("")).toBe(350);
+      expect(windowsBreakToMs("nonsense")).toBe(350);
+      expect(windowsBreakToMs("5")).toBe(350);
+    });
+  });
+
+  describe("buildWindowsSsmlChunks", () => {
+    test("wraps spoken text in an SSML <speak> with the voice language", () => {
+      const [ssml] = buildWindowsSsmlChunks("Hello world.", "fr-FR");
+      expect(ssml).toContain(
+        '<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="fr-FR">',
+      );
+      expect(ssml).toContain("Hello world.");
+      expect(ssml.endsWith("</speak>")).toBe(true);
+    });
+
+    test("converts break markers into real SSML <break> tags", () => {
+      const [ssml] = buildWindowsSsmlChunks(
+        'Title. <break time="0.5s" /> Body.',
+        "en-US",
+      );
+      expect(ssml).toContain('<break time="500ms"/>');
+      // The literal marker must not survive to be read aloud.
+      expect(ssml).not.toContain('time="0.5s"');
+      expect(ssml).not.toContain("&lt;break");
+    });
+
+    test("XML-escapes special characters in the spoken text", () => {
+      const [ssml] = buildWindowsSsmlChunks("Tom & Jerry: 2 < 3 > 1", "en-US");
+      expect(ssml).toContain("Tom &amp; Jerry: 2 &lt; 3 &gt; 1");
+    });
+
+    test("splits long text into multiple well-formed SSML chunks", () => {
+      const long = "Sentence number one is here. ".repeat(400); // ~11k chars
+      const chunks = buildWindowsSsmlChunks(long, "en-US", 4000);
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.startsWith("<speak")).toBe(true);
+        expect(chunk.endsWith("</speak>")).toBe(true);
+      }
+    });
+
+    test("never splits a break marker across a chunk boundary", () => {
+      // Force many small chunks with markers throughout; every emitted break
+      // must be a complete tag, never a stray fragment.
+      const text = Array.from(
+        { length: 50 },
+        (_v, i) => `Item ${i}. <break time="0.2s" /> `,
+      ).join("");
+      const chunks = buildWindowsSsmlChunks(text, "en-US", 60);
+      const joined = chunks.join("");
+      // Real breaks only; no leftover literal markers or half-tags.
+      expect(joined).toContain('<break time="200ms"/>');
+      expect(joined).not.toContain('time="0.2s"');
+    });
+  });
+
+  describe("parseWindowsVoices", () => {
+    const raw = [
+      {
+        engine: "onecore",
+        name: "Microsoft Hortense",
+        lang: "fr-FR",
+        gender: "Female",
+      },
+      {
+        engine: "sapi",
+        name: "Microsoft Zira Desktop",
+        lang: "en-US",
+        gender: "Female",
+      },
+    ];
+
+    test("maps voices with an engine-qualified id and a friendly label", () => {
+      const voices = parseWindowsVoices(raw);
+      expect(voices).toContainEqual({
+        id: "onecore|Microsoft Hortense",
+        label: "Hortense (Female)",
+        lang: "fr-FR",
+      });
+      expect(voices).toContainEqual({
+        id: "sapi|Microsoft Zira Desktop",
+        label: "Zira Desktop (Female)",
+        lang: "en-US",
+      });
+    });
+
+    test("defaults an unknown engine to onecore", () => {
+      const [v] = parseWindowsVoices([{ name: "Some Voice", lang: "en-GB" }]);
+      expect(v.id).toBe("onecore|Some Voice");
+    });
+
+    test("omits the gender suffix when unset or neutral", () => {
+      const voices = parseWindowsVoices([
+        { engine: "onecore", name: "A", lang: "en-US", gender: "NotSet" },
+        { engine: "onecore", name: "B", lang: "en-US", gender: "Neutral" },
+      ]);
+      expect(voices.map((v) => v.label)).toEqual(["A", "B"]);
+    });
+
+    test("drops entries without a name and dedupes by id", () => {
+      const voices = parseWindowsVoices([
+        { engine: "onecore", lang: "en-US" },
+        raw[0],
+        raw[0],
+      ]);
+      expect(voices).toHaveLength(1);
+      expect(voices[0].id).toBe("onecore|Microsoft Hortense");
+    });
+
+    test("accepts a single object or nullish input", () => {
+      expect(parseWindowsVoices(raw[0])).toHaveLength(1);
+      expect(parseWindowsVoices(null)).toEqual([]);
+      expect(parseWindowsVoices(undefined)).toEqual([]);
+    });
+
+    test("falls back to en-US when a voice reports no language", () => {
+      const [v] = parseWindowsVoices([{ engine: "sapi", name: "X" }]);
+      expect(v.lang).toBe("en-US");
+    });
+  });
+
+  describe("parseChunkLine", () => {
+    test("parses a CHUNK protocol line", () => {
+      expect(parseChunkLine("CHUNK 0 mp3 C:\\tmp\\chunk_0.mp3")).toEqual({
+        index: 0,
+        format: "mp3",
+        path: "C:\\tmp\\chunk_0.mp3",
+      });
+    });
+
+    test("keeps spaces in the path", () => {
+      const parsed = parseChunkLine("CHUNK 2 wav C:\\my notes\\chunk_2.wav");
+      expect(parsed).toEqual({
+        index: 2,
+        format: "wav",
+        path: "C:\\my notes\\chunk_2.wav",
+      });
+    });
+
+    test("returns null for non-CHUNK lines", () => {
+      expect(parseChunkLine("DONE")).toBeNull();
+      expect(parseChunkLine("VOICES []")).toBeNull();
+      expect(parseChunkLine("")).toBeNull();
+    });
+  });
+
+  describe("isWindowsDesktop", () => {
+    test("returns a boolean without throwing", () => {
+      expect(typeof isWindowsDesktop()).toBe("boolean");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds **Windows Native** as a sixth TTS provider, backed by the speech engine built into Windows — **no API key, no account, no network**. Synthesis runs entirely on the user's PC. Desktop + Windows only; every entry point is gated by `isWindowsDesktop()` and reports a clear message elsewhere (mobile, macOS, Linux).

This is complementary to the in-flight Piper PR (#67): Piper is a self-hosted neural server, whereas this uses the voices already installed in Windows with zero setup. It is intentionally self-contained — it touches no shared pipeline files, so it should not conflict with #67.

## Type of change

- [ ] fix — bug fix (patch)
- [x] feat — new feature (minor)
- [ ] docs — documentation only
- [ ] refactor / chore — no user-facing change
- [ ] BREAKING CHANGE (explain below)

## Changes

- **`WindowsSpeechService.ts`** *(new)* — the provider. A `text`-input provider that rebuilds the plain-text pipeline output into **SSML** so the native engine honours `<break>` pauses (headings/paragraphs/lists) instead of reading the markers aloud. Chunks long notes, concatenates the resulting MP3 blobs, and streams synthesis progress to the player. Pure helpers (`buildWindowsSsmlChunks`, `parseWindowsVoices`, `parseChunkLine`, `windowsBreakToMs`) are exported for unit testing.
- **`winttsScript.ts`** *(new)* — the PowerShell bridge, embedded as a string and written to a temp `.ps1` at runtime (the plugin still ships only `main.js`). It synthesizes each chunk via `Windows.Media.SpeechSynthesis` (modern **OneCore** voices) or `System.Speech` (legacy **SAPI** desktop voices) and transcodes to MP3 with the WinRT `MediaTranscoder` (WAV fallback when a system has no MP3 encoder). Communicates over a small line protocol (`VOICES` / `CHUNK` / `DONE` / `ERROR`).
- **`SpeechProviderFactory.ts`** — `windows` branch; passes `windowsVoiceCatalog` through (same pattern as Azure).
- **`VoiceSettings.ts`** — `"windows"` added to `TtsProvider`; `WINDOWS_VOICE` and `windowsVoiceCatalog` fields.
- **`VoiceSettingTab.ts`** — Windows settings section; the existing "Test Credentials" panel doubles as a **voice scan** that caches the installed-voice catalog (mirrors the Azure catalog flow).
- **`VoicePlugin.ts`** — `persistActiveVoice` branch; a background voice scan on load / provider switch when no catalog is cached yet, defaulting the active voice to one matching the app locale.
- **`VoicePlayerView.ts`** — `{ id: "windows", label: "Windows Native" }` in the player's `PROVIDERS` list.
- **`windows-speech.unit.test.ts`** *(new)* — 18 unit tests for the pure logic (SSML pause conversion incl. XML escaping and chunk-boundary safety, voice mapping/dedup, protocol line parsing, ms conversion). Platform-independent, so they run in CI on any OS.
- **`README.md`** — documents the new offline provider.

## Provider impact

- [x] None — no provider-specific behaviour changed

> Windows Native is a new addition; the five existing providers are untouched. It does not modify `SpeechProvider`/`BaseSpeechService`/`TextSpeaker`/`AudioFileManager`, so it is orthogonal to #67.

## Platform impact

- [x] Desktop
- [ ] Mobile (iOS / Android)

> Windows desktop only. The provider is gated by `isWindowsDesktop()` (`process.platform === "win32"` in the desktop app); on mobile/macOS/Linux it returns a clear "only available on Windows" message and is otherwise inert. Uses Windows PowerShell 5.1 (`powershell.exe`) — `pwsh` 7 is **not** used, as it lacks the WinRT projection the bridge relies on. The four Node built-in imports are scoped behind an ESLint disable with a justifying comment.

## How to test

1. On Windows, in **Settings → Voice → Speech Provider**, select **Windows Native (offline)**.
2. Press **Test Credentials** — expect "✓ Credentials valid! Found N voices available." (N = voices installed on the PC).
3. Open a note and press **Play** — audio plays with the native voice, fully offline. Headings/paragraphs get natural pauses; the literal `break time` markers are **not** spoken.
4. In the Voice player, switch the **voice** dropdown between installed voices (OneCore and SAPI) and re-play.
5. Save the audio and confirm a valid `.mp3` is written and embeds correctly.
6. Switch back to any other provider and confirm its behaviour is unchanged.
7. (Optional) Add a language under **Windows Settings → Time & Language → Speech → Manage voices**, then press **Test Credentials** again — the new voice appears in the picker.

> Verified end-to-end on Windows 10 Pro against the compiled `main.js`: voice enumeration, OneCore + SAPI synthesis to valid MP3 (ID3 header confirmed), accented/French text, XML-special characters, multi-chunk notes, and mid-synthesis cancellation.

## Checklist

- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm run lint:check` passes
- [x] `npm test` passes (178 tests, incl. 18 new)
- [x] Added/updated tests where it makes sense
- [x] Updated docs (README) since a new provider/settings were added
- [x] PR title follows Conventional Commits
- [x] No secrets/credentials committed

## Notes / limitations

- Requires Windows PowerShell 5.1, which ships with every supported Windows version.
- On Windows "N" editions without the Media Feature Pack (no MP3 encoder), synthesis falls back to WAV for playback; installing the Media Feature Pack restores MP3 (and thus save/embed) support.
