### PR TITLE
fix(ci): build and verify before tagging so a failed build leaves no dangling release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
 
+# Ordering matters: the plugin artifacts are installed, linted, built and
+# verified BEFORE the version is bumped, the tag is created/pushed and the
+# GitHub release is published. Pushing the tag is the first irreversible action,
+# so it must only happen once the build has succeeded. The previous order tagged
+# and bumped the manifest first and built afterwards — when the build step
+# failed it left a dangling tag + a bumped versions.json on main with no release
+# assets, which Obsidian then tried (and failed, HTTP 404) to install.
 jobs:
   create_release:
     name: Create Release
@@ -68,53 +75,10 @@ jobs:
             echo "tag_exists=false" >> $GITHUB_ENV
           fi
 
-      - name: Update package.json version
-        if: env.tag_exists == 'false'
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
-          echo "Updating package.json to version $NEW_VERSION"
-          jq --arg version "$NEW_VERSION" '.version = $version' package.json > package.tmp.json && mv package.tmp.json package.json
-
-      - name: Update manifest.json version
-        if: env.tag_exists == 'false'
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
-          echo "Updating manifest.json to version $NEW_VERSION"
-          jq --arg version "$NEW_VERSION" '.version = $version' manifest.json > manifest.tmp.json && mv manifest.tmp.json manifest.json
-          
-      - name: Update versions.json
-        if: env.tag_exists == 'false'
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
-          MIN_APP_VERSION=$(jq -r '.minAppVersion' manifest.json)
-          echo "Updating versions.json with version $NEW_VERSION (minAppVersion: $MIN_APP_VERSION)"
-          
-          # Create or update versions.json
-          if [ -f versions.json ]; then
-            # Update existing file
-            jq --arg version "$NEW_VERSION" --arg minApp "$MIN_APP_VERSION" '.[$version] = $minApp' versions.json > versions.tmp.json && mv versions.tmp.json versions.json
-          else
-            # Create new file
-            echo "{\"$NEW_VERSION\": \"$MIN_APP_VERSION\"}" > versions.json
-          fi
-
-      - name: Create and commit tag
-        if: env.tag_exists == 'false'
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add package.json manifest.json versions.json
-          git commit -m "chore(release): update version to ${{ steps.version.outputs.version }}"
-          git tag -a ${{ steps.version.outputs.version }} -m "Release ${{ steps.version.outputs.version }}"
-          echo "Created tag ${{ steps.version.outputs.version }}"
-
-      - name: Push changes to repository
-        if: env.tag_exists == 'false'
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
-          tags: true
+      # ── Build & verify FIRST ────────────────────────────────────────────────
+      # Everything below through "Verify required plugin files" runs before any
+      # tag/commit/release. If any of these fail the job stops here with no tag
+      # pushed and no release created — the repository is left untouched.
 
       - name: Install project dependencies
         run: |
@@ -153,6 +117,59 @@ jobs:
 
           echo "✅ Plugin structure is valid"
           echo "artifact_ready=true" >> $GITHUB_ENV
+
+      # ── Only now bump, tag, push and release ────────────────────────────────
+      # The build succeeded, so it is safe to take the irreversible steps.
+      # (main.js is version-independent — the plugin reads its version from the
+      # manifest at runtime — so building before the bump is fine.)
+
+      - name: Update package.json version
+        if: env.tag_exists == 'false'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          echo "Updating package.json to version $NEW_VERSION"
+          jq --arg version "$NEW_VERSION" '.version = $version' package.json > package.tmp.json && mv package.tmp.json package.json
+
+      - name: Update manifest.json version
+        if: env.tag_exists == 'false'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          echo "Updating manifest.json to version $NEW_VERSION"
+          jq --arg version "$NEW_VERSION" '.version = $version' manifest.json > manifest.tmp.json && mv manifest.tmp.json manifest.json
+
+      - name: Update versions.json
+        if: env.tag_exists == 'false'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          MIN_APP_VERSION=$(jq -r '.minAppVersion' manifest.json)
+          echo "Updating versions.json with version $NEW_VERSION (minAppVersion: $MIN_APP_VERSION)"
+
+          # Create or update versions.json
+          if [ -f versions.json ]; then
+            # Update existing file
+            jq --arg version "$NEW_VERSION" --arg minApp "$MIN_APP_VERSION" '.[$version] = $minApp' versions.json > versions.tmp.json && mv versions.tmp.json versions.json
+          else
+            # Create new file
+            echo "{\"$NEW_VERSION\": \"$MIN_APP_VERSION\"}" > versions.json
+          fi
+
+      - name: Create and commit tag
+        if: env.tag_exists == 'false'
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add package.json manifest.json versions.json
+          git commit -m "chore(release): update version to ${{ steps.version.outputs.version }}"
+          git tag -a ${{ steps.version.outputs.version }} -m "Release ${{ steps.version.outputs.version }}"
+          echo "Created tag ${{ steps.version.outputs.version }}"
+
+      - name: Push changes to repository
+        if: env.tag_exists == 'false'
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+          tags: true
 
       - name: Attest build provenance for release assets
         if: env.tag_exists == 'false' && env.artifact_ready == 'true'


### PR DESCRIPTION
## Summary

Users hit **"Failed to install plugin 'Voice'"** with an **HTTP 404** in the console. Root cause: the release workflow bumped the version, committed and **pushed the tag first**, and only **built and published the release afterwards**. When the build step failed (the yarn lockfile error during the #69 release), tag `1.16.1` and the `versions.json` entry were already on `main`, but the "Create GitHub release" step never ran — so **tag `1.16.1` exists with no release assets**. Obsidian resolved version 1.16.1 and tried to download `releases/download/1.16.1/main.js` → 404 → install fails.

This reorders the workflow so the irreversible steps (tag push + release) only happen **after** a successful build.

## Type of change

- [x] fix — bug fix (patch)
- [ ] feat — new feature (minor)
- [ ] docs — documentation only
- [ ] refactor / chore — no user-facing change
- [ ] BREAKING CHANGE (explain below)

## Root cause (evidence)

| Version | Tag | GitHub release |
|---|---|---|
| 1.16.0 | ✅ | ✅ |
| **1.16.1** | ✅ `625d098` | ❌ **404 — no release** |
| 1.16.2 | ✅ | ✅ |

The old step order was: bump → commit → **tag + push** → install → build → **create release**. A failure between the tag push and release creation (exactly what the yarn error caused) leaves a tag + `versions.json` entry that Obsidian can see but cannot download.

## Changes

- `.github/workflows/release.yml`: move `npm ci`, lint, build and "Verify required plugin files" **before** the version bump, tag creation/push, attestation and release. Pushing the tag is now gated behind a successful build, so a build failure aborts with the repo untouched (no dangling tag, no half-published version). `main.js` is version-independent (the plugin reads its version from the manifest at runtime), so building before the bump is safe.

## Provider impact

- [x] None — no provider-specific behaviour changed

## Platform impact

- [x] Desktop
- [x] Mobile (iOS / Android)

_CI-only change; no runtime code touched._

## How to test

1. Normal path: on merge to `main`, the release builds first, then tags and publishes — the new release has all three assets.
2. Failure path (the regression this fixes): if the build/lint/install fails, the job stops before any tag is pushed — no dangling tag or `versions.json` entry is left behind.

## Note — healing the existing 1.16.1

This prevents recurrence but does not retroactively create the missing 1.16.1 release. That has to be healed separately (backfill a 1.16.1 GitHub release with valid assets, or let Obsidian's registry advance to 1.16.2 which already has a valid release). See the follow-up in the conversation.

## Checklist

- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm run lint:check` passes
- [x] `npm test` passes
- [x] PR title follows Conventional Commits
- [x] No secrets/credentials committed


---
_Generated by [Claude Code](https://claude.ai/code/session_01SyFh958nxJcV1SgxvsUxyh)_