### PR TITLE
feat: add Kokoro local TTS provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voice",
-  "version": "1.16.0",
+  "version": "1.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voice",
-      "version": "1.16.0",
+      "version": "1.16.3",
       "license": "MIT",
       "dependencies": {
         "remark-frontmatter": "^5.0.0",

--- a/src/service/AwsPollyService.ts
+++ b/src/service/AwsPollyService.ts
@@ -44,6 +44,7 @@ interface SynthesizeInput {
 
 export class AwsPollyService extends BaseSpeechService {
   readonly inputFormat = "ssml" as const;
+  readonly supportsBreakTags = false;
 
   private synthesizeInput: {
     Engine: Engine;

--- a/src/service/AzureSpeechService.ts
+++ b/src/service/AzureSpeechService.ts
@@ -28,6 +28,7 @@ const MAX_SSML_CHUNK_CHARS = 2500;
 
 export class AzureSpeechService extends BaseSpeechService {
   readonly inputFormat = "ssml" as const;
+  readonly supportsBreakTags = false;
 
   private apiKey: string;
   private region: string;

--- a/src/service/BaseSpeechService.ts
+++ b/src/service/BaseSpeechService.ts
@@ -49,6 +49,7 @@ export abstract class BaseSpeechService implements SpeechProvider {
   // --- Provider-specific members implemented by subclasses ---
 
   abstract readonly inputFormat: "ssml" | "text";
+  abstract readonly supportsBreakTags: boolean;
   abstract speak(
     content: string,
     speed?: number,

--- a/src/service/ElevenLabsService.ts
+++ b/src/service/ElevenLabsService.ts
@@ -28,6 +28,7 @@ const MAX_CHUNK_CHARS = 3000;
 
 export class ElevenLabsService extends BaseSpeechService {
   readonly inputFormat = "text" as const;
+  readonly supportsBreakTags = true;
 
   private apiKey: string;
   private model: string;

--- a/src/service/GoogleTtsService.ts
+++ b/src/service/GoogleTtsService.ts
@@ -39,6 +39,7 @@ function base64ToBytes(base64: string): Uint8Array {
 
 export class GoogleTtsService extends BaseSpeechService {
   readonly inputFormat = "ssml" as const;
+  readonly supportsBreakTags = false;
 
   private apiKey: string;
 

--- a/src/service/KokoroSpeechService.ts
+++ b/src/service/KokoroSpeechService.ts
@@ -1,6 +1,6 @@
 import { requestUrl } from "obsidian";
 import {
-  OPENAI_VOICES,
+  KOKORO_VOICES,
   type VoiceOption,
   type VoiceSettings,
 } from "../settings/VoiceSettings";
@@ -9,49 +9,59 @@ import type { CredentialValidationResult } from "./SpeechProvider";
 import { chunkPlainText } from "./textChunker";
 
 /**
- * OpenAI Text-to-Speech integration.
+ * Kokoro TTS integration (local or self-hosted via Kokoro-FastAPI).
  *
- * - Receives plain spoken text from TextSpeaker (OpenAI's speech endpoint does
- *   not support SSML, so the text pipeline is used instead of the SSML pipeline).
+ * - Receives plain spoken text from TextSpeaker (Kokoro accepts plain text).
  * - Chunks long notes to stay within the per-request input limit and
  *   concatenates the resulting MP3 blobs.
- * - Uses Obsidian's requestUrl() with a Bearer token to bypass browser CORS
- *   (same rationale as the other HTTP providers) and to keep the key out of
- *   fetch/XHR client requests.
- * - Playback/controls/caching are inherited from BaseSpeechService. Speed is
- *   applied client-side via the audio element, so it is not sent to the API.
+ * - Uses Obsidian's requestUrl() so the request works inside Obsidian's
+ *   sandboxed environment and avoids browser CORS issues.
+ * - No API key is required; the endpoint is assumed to be reachable on the
+ *   configured base URL (default http://localhost:8880).
  */
 
-const OPENAI_BASE_URL = "https://api.openai.com/v1";
-// Conservative per-request size. The speech endpoint accepts up to ~4096
-// characters; smaller chunks lower first-audio latency and stay safely under
-// the limit for every model.
+const DEFAULT_KOKORO_BASE_URL = "http://localhost:8880";
+// Kokoro-FastAPI is comfortable with a few thousand characters; keep a
+// conservative limit to avoid timeouts and to enable progress feedback.
 const MAX_CHUNK_CHARS = 2000;
 
-export class OpenAiSpeechService extends BaseSpeechService {
+export class KokoroSpeechService extends BaseSpeechService {
   readonly inputFormat = "text" as const;
-  readonly supportsBreakTags = true;
+  readonly supportsBreakTags = false;
 
-  private apiKey: string;
+  private baseUrl: string;
   private model: string;
+  private langCode: string;
 
-  constructor(apiKey: string, voice: string, model: string, speed?: number) {
+  constructor(
+    baseUrl: string,
+    voice: string,
+    model: string,
+    langCode: string,
+    speed?: number,
+  ) {
     super(voice, speed);
-    this.apiKey = apiKey;
-    this.model = model || "gpt-4o-mini-tts";
+    this.baseUrl = (baseUrl || DEFAULT_KOKORO_BASE_URL).replace(/\/$/, "");
+    this.model = model || "kokoro";
+    this.langCode = langCode || "p";
   }
 
   getVoiceOptions(): VoiceOption[] {
-    return OPENAI_VOICES;
+    return KOKORO_VOICES;
   }
 
   updateCredentials(settings: VoiceSettings): void {
-    this.apiKey = settings.OPENAI_API_KEY;
-    this.model = settings.OPENAI_MODEL || "gpt-4o-mini-tts";
+    this.baseUrl = (settings.KOKORO_BASE_URL || DEFAULT_KOKORO_BASE_URL).replace(
+      /\/$/,
+      "",
+    );
+    this.voice = settings.KOKORO_VOICE;
+    this.model = settings.KOKORO_MODEL || "kokoro";
+    this.langCode = settings.KOKORO_LANG_CODE || "p";
   }
 
   /**
-   * Synthesize and play plain text via OpenAI.
+   * Synthesize and play plain text via a local Kokoro-FastAPI endpoint.
    */
   async speak(
     content: string,
@@ -59,13 +69,7 @@ export class OpenAiSpeechService extends BaseSpeechService {
     filePath?: string,
   ): Promise<void> {
     if (this.isLoading) {
-      throw new Error("OpenAI call already in progress.");
-    }
-
-    if (!this.apiKey) {
-      const error = new Error("Missing OpenAI API key");
-      this.reportError(error);
-      throw error;
+      throw new Error("Kokoro TTS call already in progress.");
     }
 
     const text = content.trim();
@@ -92,8 +96,6 @@ export class OpenAiSpeechService extends BaseSpeechService {
         }
 
         audioBlobs.push(blob);
-
-        // Reserve the last slice of the bar for concatenation + buffering.
         this.reportProgress(((i + 1) / chunks.length) * 0.95, 1);
       }
 
@@ -103,7 +105,7 @@ export class OpenAiSpeechService extends BaseSpeechService {
       if (error instanceof Error && error.name === "AbortError") {
         return;
       }
-      console.error("Error in OpenAI speak:", error);
+      console.error("Error in Kokoro speak:", error);
       this.reportError(error);
       throw error;
     } finally {
@@ -117,10 +119,9 @@ export class OpenAiSpeechService extends BaseSpeechService {
    */
   private async synthesizeChunk(text: string): Promise<Blob> {
     const response = await requestUrl({
-      url: `${OPENAI_BASE_URL}/audio/speech`,
+      url: `${this.baseUrl}/v1/audio/speech`,
       method: "POST",
       headers: {
-        Authorization: `Bearer ${this.apiKey}`,
         "Content-Type": "application/json",
         Accept: "audio/mpeg",
       },
@@ -128,21 +129,22 @@ export class OpenAiSpeechService extends BaseSpeechService {
         model: this.model,
         input: text,
         voice: this.voice,
+        lang_code: this.langCode,
         response_format: "mp3",
+        speed: 1.0,
       }),
       throw: false,
     });
 
-    if (response.status === 401) {
-      throw new Error("OpenAI: invalid or expired API key (401)");
-    }
-    if (response.status === 429) {
-      throw new Error("OpenAI: rate limit or quota reached (429)");
+    if (response.status === 404) {
+      throw new Error(
+        "Kokoro TTS endpoint not found. Is Kokoro running at the configured URL?",
+      );
     }
     if (response.status >= 400) {
-      const message = response.json?.error?.message;
+      const message = response.json?.error?.message || response.text;
       throw new Error(
-        `OpenAI API error (HTTP ${response.status})${
+        `Kokoro TTS error (HTTP ${response.status})${
           message ? `: ${message}` : ""
         }`,
       );
@@ -150,45 +152,42 @@ export class OpenAiSpeechService extends BaseSpeechService {
 
     const arrayBuffer = response.arrayBuffer;
     if (!arrayBuffer || arrayBuffer.byteLength === 0) {
-      throw new Error("OpenAI returned an empty audio response");
+      throw new Error("Kokoro returned an empty audio response");
     }
 
     return new Blob([arrayBuffer], { type: "audio/mpeg" });
   }
 
   /**
-   * Validate the API key. OpenAI has no list-voices endpoint, so we probe the
-   * models endpoint; a 200 means the key works. The voice count reflects the
-   * built-in catalog.
+   * Validate the Kokoro endpoint by probing the /v1/models route.
    */
   async validateCredentials(): Promise<CredentialValidationResult> {
-    if (!this.apiKey) {
-      return { isValid: false, error: "Please enter your OpenAI API key." };
-    }
-
     try {
       const response = await requestUrl({
-        url: `${OPENAI_BASE_URL}/models`,
+        url: `${this.baseUrl}/v1/models`,
         method: "GET",
-        headers: { Authorization: `Bearer ${this.apiKey}` },
         throw: false,
       });
 
       if (response.status === 200) {
-        return { isValid: true, voiceCount: OPENAI_VOICES.length };
+        return { isValid: true, voiceCount: KOKORO_VOICES.length };
       }
-      if (response.status === 401) {
-        return { isValid: false, error: "Invalid or expired OpenAI API key." };
+      if (response.status === 404) {
+        return {
+          isValid: false,
+          error: "Kokoro endpoint not found. Check the base URL.",
+        };
       }
       return {
         isValid: false,
         error: `Validation failed (HTTP ${response.status}).`,
       };
     } catch (error) {
-      console.error("OpenAI credential validation error:", error);
+      console.error("Kokoro credential validation error:", error);
       return {
         isValid: false,
-        error: "Network error during validation. Please try again.",
+        error:
+          "Could not reach Kokoro TTS. Make sure the server is running and reachable.",
       };
     }
   }
@@ -197,23 +196,17 @@ export class OpenAiSpeechService extends BaseSpeechService {
     if (error && typeof error === "object" && "message" in error) {
       const message = String((error as { message: string }).message);
 
-      if (message.includes("401")) {
-        return "Invalid OpenAI API key.";
-      }
-      if (message.includes("429")) {
-        return "OpenAI rate limit or quota reached. Please wait and try again.";
-      }
-      if (message.includes("Missing OpenAI API key")) {
-        return "Add your OpenAI API key in settings.";
+      if (message.includes("404")) {
+        return "Kokoro TTS endpoint not found. Check the base URL and make sure the server is running.";
       }
       if (message.includes("empty audio")) {
-        return "OpenAI returned no audio. Try a different voice or model.";
+        return "Kokoro returned no audio. Try a different voice or lang_code.";
       }
       if (message.toLowerCase().includes("network")) {
-        return "Connection failed. Check your internet.";
+        return "Connection failed. Check that Kokoro TTS is running.";
       }
-      return `OpenAI error: ${message}`;
+      return `Kokoro error: ${message}`;
     }
-    return "OpenAI error. Please try again.";
+    return "Kokoro TTS error. Please try again.";
   }
 }

--- a/src/service/SpeechProvider.ts
+++ b/src/service/SpeechProvider.ts
@@ -37,6 +37,12 @@ export interface SpeechProvider {
   readonly inputFormat: "ssml" | "text";
 
   /**
+   * Whether this provider understands ElevenLabs-style `<break time="..."/>`
+   * pause tags in plain-text input. When false, the text pipeline strips them.
+   */
+  readonly supportsBreakTags: boolean;
+
+  /**
    * Synthesize and play the given processed content.
    */
   speak(content: string, speed?: number, filePath?: string): Promise<void>;

--- a/src/service/SpeechProviderFactory.ts
+++ b/src/service/SpeechProviderFactory.ts
@@ -9,6 +9,7 @@ import { ElevenLabsService } from "./ElevenLabsService";
 import { GoogleTtsService } from "./GoogleTtsService";
 import { AzureSpeechService } from "./AzureSpeechService";
 import { OpenAiSpeechService } from "./OpenAiSpeechService";
+import { KokoroSpeechService } from "./KokoroSpeechService";
 
 /**
  * Create the speech provider selected in settings.
@@ -42,6 +43,14 @@ export function createSpeechProvider(settings: VoiceSettings): SpeechProvider {
       settings.OPENAI_API_KEY,
       settings.OPENAI_VOICE,
       settings.OPENAI_MODEL,
+      Number(settings.SPEED),
+    );
+  } else if (settings.TTS_PROVIDER === "kokoro") {
+    provider = new KokoroSpeechService(
+      settings.KOKORO_BASE_URL,
+      settings.KOKORO_VOICE,
+      settings.KOKORO_MODEL,
+      settings.KOKORO_LANG_CODE,
       Number(settings.SPEED),
     );
   } else {

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -4,6 +4,7 @@ import {
   ELEVENLABS_MODELS,
   AZURE_REGIONS,
   OPENAI_MODELS,
+  KOKORO_VOICES,
   MIN_SKIP_SECONDS,
   MAX_SKIP_SECONDS,
 } from "./VoiceSettings";
@@ -64,6 +65,7 @@ export class VoiceSettingTab extends PluginSettingTab {
           .addOption("google", "Google Cloud")
           .addOption("azure", "Azure Speech")
           .addOption("openai", "OpenAI")
+          .addOption("kokoro", "Kokoro (local)")
           .setValue(this.plugin.settings.TTS_PROVIDER)
           .onChange(async (value) => {
             this.plugin.settings.TTS_PROVIDER = value as
@@ -71,7 +73,8 @@ export class VoiceSettingTab extends PluginSettingTab {
               | "elevenlabs"
               | "google"
               | "azure"
-              | "openai";
+              | "openai"
+              | "kokoro";
             await this.plugin.saveSettings();
             // Swap the active provider and rewire the UI/orchestration
             this.plugin.reinitializeProvider();
@@ -190,6 +193,8 @@ export class VoiceSettingTab extends PluginSettingTab {
       this.displayAzureSettings(containerEl);
     } else if (this.plugin.settings.TTS_PROVIDER === "openai") {
       this.displayOpenAISettings(containerEl);
+    } else if (this.plugin.settings.TTS_PROVIDER === "kokoro") {
+      this.displayKokoroSettings(containerEl);
     } else {
       this.displayPollySettings(containerEl);
     }
@@ -237,6 +242,62 @@ export class VoiceSettingTab extends PluginSettingTab {
         "Enter your OpenAI API key above, then click 'Test Credentials' to validate",
       helpText: "Need an OpenAI API key? ",
       helpUrl: "https://platform.openai.com/api-keys",
+    });
+  }
+
+  private displayKokoroSettings(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("Kokoro TTS").setHeading();
+
+    this.addTextSetting(
+      containerEl,
+      "Base URL",
+      "The local Kokoro-FastAPI endpoint (e.g. http://localhost:8880).",
+      "http://localhost:8880",
+      this.plugin.settings.KOKORO_BASE_URL,
+      async (value) => {
+        this.plugin.settings.KOKORO_BASE_URL = value;
+        await this.plugin.saveSettings();
+        this.plugin.reinitializeProviderCredentials();
+      },
+    );
+
+    new Setting(containerEl)
+      .setName("Voice")
+      .setDesc("The Kokoro voice pack to use for synthesis.")
+      .addDropdown((dropdown) => {
+        KOKORO_VOICES.forEach((voice) => {
+          dropdown.addOption(voice.id, voice.label);
+        });
+        dropdown
+          .setValue(this.plugin.settings.KOKORO_VOICE)
+          .onChange(async (value) => {
+            this.plugin.settings.KOKORO_VOICE = value;
+            await this.plugin.saveSettings();
+            this.plugin.reinitializeProviderCredentials();
+          });
+      });
+
+    this.addTextSetting(
+      containerEl,
+      "Model",
+      "The model identifier sent to Kokoro (usually 'kokoro').",
+      "kokoro",
+      this.plugin.settings.KOKORO_MODEL,
+      async (value) => {
+        this.plugin.settings.KOKORO_MODEL = value;
+        await this.plugin.saveSettings();
+        this.plugin.reinitializeProviderCredentials();
+      },
+    );
+
+    this.renderCredentialValidation(containerEl, {
+      providerName: "Kokoro",
+      isConfigured: () => !!this.plugin.settings.KOKORO_BASE_URL,
+      missingMessage: "Please enter the Kokoro base URL before testing.",
+      promptMessage:
+        "Enter the Kokoro base URL above, then click 'Test Credentials' to validate",
+      helpText: "Need a local Kokoro server? ",
+      helpUrl: "https://github.com/remsky/Kokoro-FastAPI",
     });
   }
 
@@ -477,6 +538,25 @@ export class VoiceSettingTab extends PluginSettingTab {
               button.setTooltip(isVisible ? "Hide" : "Show");
             }
           });
+      });
+  }
+
+  /**
+   * Render a plain text setting (no password toggle).
+   */
+  private addTextSetting(
+    containerEl: HTMLElement,
+    name: string,
+    desc: string,
+    placeholder: string,
+    value: string,
+    onChange: (value: string) => Promise<void>,
+  ): void {
+    new Setting(containerEl)
+      .setName(name)
+      .setDesc(desc)
+      .addText((text) => {
+        text.setPlaceholder(placeholder).setValue(value).onChange(onChange);
       });
   }
 

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -6,7 +6,8 @@ export type TtsProvider =
   | "elevenlabs"
   | "google"
   | "azure"
-  | "openai";
+  | "openai"
+  | "kokoro";
 
 /**
  * Where saved MP3s are written.
@@ -51,6 +52,12 @@ export interface VoiceSettings {
   OPENAI_API_KEY: string;
   OPENAI_VOICE: string;
   OPENAI_MODEL: string;
+
+  // Kokoro TTS (local / self-hosted)
+  KOKORO_BASE_URL: string;
+  KOKORO_VOICE: string;
+  KOKORO_LANG_CODE: string;
+  KOKORO_MODEL: string;
 
   // Content / speech options (shared across providers)
   spellOutAcronyms: boolean;
@@ -119,6 +126,22 @@ export interface ModelOption {
   label: string;
 }
 
+export interface KokoroLanguageOption {
+  id: string;
+  label: string;
+}
+
+export const KOKORO_LANGUAGES: KokoroLanguageOption[] = [
+  { id: "a", label: "American English" },
+  { id: "b", label: "British English" },
+  { id: "e", label: "Spanish" },
+  { id: "f", label: "French" },
+  { id: "h", label: "Hindi" },
+  { id: "i", label: "Italian" },
+  { id: "j", label: "Japanese" },
+  { id: "p", label: "Brazilian Portuguese" },
+  { id: "z", label: "Mandarin Chinese" },
+];
 export const VOICES: VoiceOption[] = [
   { id: "Stephen", label: "Stephen (American)", lang: "en-US" },
   { id: "Joanna", label: "Joanna (American)", lang: "en-US" },
@@ -347,6 +370,28 @@ export const OPENAI_VOICES: VoiceOption[] = [
   { id: "shimmer", label: "Shimmer (Soft)", lang: "en-US" },
 ];
 
+/**
+ * Kokoro voice pack selection. The `id` is the pack name accepted by
+ * Kokoro-FastAPI's /v1/audio/speech endpoint; `lang` reflects the language
+ * the pack speaks best.
+ */
+export const KOKORO_VOICES: VoiceOption[] = [
+  { id: "pm_alex", label: "Alex (Portuguese, Brazilian, Male)", lang: "pt-BR" },
+  { id: "pf_dora", label: "Dora (Portuguese, Brazilian, Female)", lang: "pt-BR" },
+  { id: "af_heart", label: "Heart (American, Female)", lang: "en-US" },
+  { id: "am_michael", label: "Michael (American, Male)", lang: "en-US" },
+  { id: "af_bella", label: "Bella (American, Female)", lang: "en-US" },
+  { id: "am_adam", label: "Adam (American, Male)", lang: "en-US" },
+  { id: "bf_emma", label: "Emma (British, Female)", lang: "en-GB" },
+  { id: "bm_george", label: "George (British, Male)", lang: "en-GB" },
+  { id: "jf_alpha", label: "Alpha (Japanese, Female)", lang: "ja-JP" },
+  { id: "jm_kumo", label: "Kumo (Japanese, Male)", lang: "ja-JP" },
+  { id: "ef_domi", label: "Domi (Spanish, Female)", lang: "es-ES" },
+  { id: "em_santa", label: "Santa (Spanish, Male)", lang: "es-ES" },
+  { id: "ff_siwis", label: "Siwis (French, Female)", lang: "fr-FR" },
+  { id: "if_sara", label: "Sara (Italian, Female)", lang: "it-IT" },
+];
+
 export const DEFAULT_SETTINGS: VoiceSettings = {
   TTS_PROVIDER: "polly",
 
@@ -370,6 +415,12 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   OPENAI_API_KEY: "",
   OPENAI_VOICE: "alloy",
   OPENAI_MODEL: "gpt-4o-mini-tts",
+
+  // Kokoro TTS defaults
+  KOKORO_BASE_URL: "http://localhost:8880",
+  KOKORO_VOICE: "pm_alex",
+  KOKORO_LANG_CODE: "p",
+  KOKORO_MODEL: "kokoro",
 
   spellOutAcronyms: false,
   readCodeBlocks: false,

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -8,6 +8,7 @@ import {
 } from "obsidian";
 import type { Voice } from "../utils/VoicePlugin";
 import type { TtsProvider } from "../settings/VoiceSettings";
+import { KOKORO_LANGUAGES } from "../settings/VoiceSettings";
 import {
   chapterName,
   listChapters,
@@ -34,6 +35,7 @@ const PROVIDERS: { id: TtsProvider; label: string }[] = [
   { id: "google", label: "Google Cloud" },
   { id: "azure", label: "Azure Speech" },
   { id: "openai", label: "OpenAI" },
+  { id: "kokoro", label: "Kokoro" },
 ];
 
 /**
@@ -67,6 +69,7 @@ export class VoicePlayerView extends ItemView {
   private downloadShowsSave = false;
   private providerSelect: HTMLSelectElement;
   private voiceSelect: HTMLSelectElement;
+  private kokoroLangSelect: HTMLSelectElement;
   private folderSelect: HTMLSelectElement;
   private codeBtn: HTMLElement;
   private acronymBtn: HTMLElement;
@@ -340,6 +343,21 @@ export class VoicePlayerView extends ItemView {
       this.changeVoice(this.voiceSelect.value),
     );
 
+    // Kokoro language code selector (only shown when Kokoro is active).
+    this.kokoroLangSelect = options.createEl("select", {
+      cls: "voice-player-select dropdown",
+      attr: { "aria-label": "Kokoro language" },
+    });
+    KOKORO_LANGUAGES.forEach((lang) =>
+      this.kokoroLangSelect.createEl("option", {
+        value: lang.id,
+        text: lang.label,
+      }),
+    );
+    this.registerDomEvent(this.kokoroLangSelect, "change", () =>
+      this.changeKokoroLanguage(this.kokoroLangSelect.value),
+    );
+
     // Folder picker: choose any vault folder that contains MP3s and list its
     // tracks as chapters, so the player can browse audio across the vault.
     const folderRow = root.createDiv({ cls: "voice-player-folder" });
@@ -564,6 +582,14 @@ export class VoicePlayerView extends ItemView {
     void this.plugin.persistActiveVoice(voiceId);
   }
 
+  /** Persist and apply the chosen Kokoro language code. */
+  private changeKokoroLanguage(langCode: string): void {
+    if (langCode === this.plugin.settings.KOKORO_LANG_CODE) {
+      return;
+    }
+    void this.plugin.persistKokoroLanguage(langCode);
+  }
+
   /** Toggle whether code blocks are read aloud. */
   private toggleCodeBlocks(): void {
     this.plugin.settings.readCodeBlocks = !this.plugin.settings.readCodeBlocks;
@@ -603,6 +629,9 @@ export class VoicePlayerView extends ItemView {
     }
     this.providerSelect.value = this.plugin.settings.TTS_PROVIDER;
     this.populateVoiceOptions();
+    this.kokoroLangSelect.value = this.plugin.settings.KOKORO_LANG_CODE;
+    this.kokoroLangSelect.style.display =
+      this.plugin.settings.TTS_PROVIDER === "kokoro" ? "" : "none";
     this.updateCodeButton();
     this.updateAcronymButton();
     this.updateUrlButton();

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -59,13 +59,17 @@ export class TextSpeaker {
       ...contentOptions,
     });
 
-    // Plain-text pipeline (ElevenLabs and other non-SSML providers). It also
-    // needs the acronym setting so it can title-case acronyms when spell-out is
-    // off, keeping pronunciation consistent with the SSML providers.
-    this.textProcessor = new MarkdownToTextProcessor({
-      ...contentOptions,
-      spellOutAcronyms: this.spellOutAcronyms,
-    });
+    // Plain-text pipeline (ElevenLabs, OpenAI, Kokoro). It also needs the
+    // acronym setting so it can title-case acronyms when spell-out is off,
+    // keeping pronunciation consistent with the SSML providers. Pause/break
+    // tags are only emitted when the provider understands them.
+    this.textProcessor = new MarkdownToTextProcessor(
+      {
+        ...contentOptions,
+        spellOutAcronyms: this.spellOutAcronyms,
+      },
+      { pauseTags: this.provider.supportsBreakTags },
+    );
   }
 
   async speakText(speed?: number): Promise<void> {

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -242,6 +242,17 @@ export class Voice extends Plugin {
   }
 
   /**
+   * Persist the chosen Kokoro language code, recreate the provider with the
+   * new lang_code, and refresh the player controls.
+   */
+  public async persistKokoroLanguage(langCode: string): Promise<void> {
+    this.settings.KOKORO_LANG_CODE = langCode;
+    await this.saveSettings();
+    this.reinitializeProvider();
+    this.refreshVoicePlayerControls();
+  }
+
+  /**
    * Apply the configured rewind/fast-forward skip intervals to the running
    * provider and refresh the control tooltips. Called when the user changes
    * the interval in settings (no audio interruption).


### PR DESCRIPTION
## Summary

Adds support for self-hosted **Kokoro-FastAPI** as a local text-to-speech provider, so users can listen to notes with an offline/local TTS engine without cloud credentials.

Closes #

## Type of change

- [x] feat — new feature (minor)

## Changes

- Added `KokoroSpeechService` (`src/service/KokoroSpeechService.ts`) that calls a local Kokoro-FastAPI `/v1/audio/speech` endpoint and returns MP3 audio.
- Registered Kokoro in `SpeechProviderFactory` so it can be selected as the active provider.
- Added Kokoro settings: `KOKORO_BASE_URL`, `KOKORO_VOICE`, `KOKORO_LANG_CODE`, and `KOKORO_MODEL` (`src/settings/VoiceSettings.ts`).
- Added Kokoro to the provider dropdown in `VoiceSettingTab` with Base URL, voice picker, and model inputs.
- Added Kokoro to the player provider selector (`src/ui/VoicePlayerView.ts`).
- Added a Kokoro language-code selector directly in the player for quick language switching (`a`, `b`, `e`, `f`, `h`, `i`, `j`, `p`, `z`).
- Added `supportsBreakTags` capability to `SpeechProvider`/`BaseSpeechService` and implemented it per provider.
- Updated `TextSpeaker` to emit `<break>` pause tags only for providers that support them, preventing Kokoro from reading break tags aloud.

## Provider impact

- [ ] None — no provider-specific behaviour changed
- [ ] AWS Polly
- [x] ElevenLabs — break-tag capability flag added; no functional change
- [x] OpenAI — break-tag capability flag added; no functional change
- [ ] Google Cloud
- [ ] Azure Speech

> Note: this PR also introduces a **new provider** (Kokoro).

## Platform impact

- [x] Desktop
- [x] Mobile (iOS / Android)

## How to test

1. Install and run a local Kokoro-FastAPI server, e.g. `http://localhost:8880`.
2. Open Obsidian Voice settings, select **Kokoro (local)** as the speech provider, and enter the Base URL.
3. Open a note and press play in the Voice player.
4. Verify audio is synthesized and played.
5. Use the language-code selector in the player to switch languages and verify synthesis still works.
6. Verify existing providers (OpenAI, ElevenLabs, etc.) still synthesize normally.

## Checklist

- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm run lint:check` passes
- [x] `npm test` passes
- [ ] Added/updated tests where it makes sense
- [ ] Updated docs (README / TROUBLESHOOTING) if behaviour or settings changed
- [x] PR title follows Conventional Commits
- [x] No secrets/credentials committed

## Screenshots / recordings

<!-- For UI or player changes, before/after helps a lot. -->
