### PR TITLE
feat: add Kokoro local TTS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Obsidian Voice — listen to your notes in natural, lifelike speech with AWS Polly, ElevenLabs, Google Cloud, Azure Speech, or OpenAI](./assets/hero.png)
 
-Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian Voice Plugin reads your notes aloud in natural, lifelike speech — using the text-to-speech provider you already have. It supports all the major engines — **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, and **Azure Speech** — so you can listen with whichever one you prefer. Listen with a dedicated player, jump between notes like chapters, change the speed on the fly, and save audio offline — with your credentials kept private in your own account.
+Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian Voice Plugin reads your notes aloud in natural, lifelike speech — using the text-to-speech provider you already have. It supports all the major engines — **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, **Azure Speech**, and **Kokoro** — so you can listen with whichever one you prefer. Listen with a dedicated player, jump between notes like chapters, change the speed on the fly, and save audio offline — with your credentials kept private in your own account.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 ## Highlights
 
 - **A real audiobook player** — open the Voice player, see your notes as chapters, and play, skip, and repeat just like a podcast app.
-- **Bring your own provider** — Voice supports all the major text-to-speech engines (**AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, and **Azure Speech**), so you can listen with whichever one you already use. Every feature works the same on all of them.
+- **Bring your own provider** — Voice supports all the major text-to-speech engines (**AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, **Azure Speech**, and self-hosted **Kokoro**), so you can listen with whichever one you already use. Every feature works the same on all of them.
 - **Listen in seconds** — turn any note into lifelike speech straight from the ribbon, a command, or the player.
 - **Designed for every device** — the same experience on desktop, iOS, and Android, with a touch-friendly mobile player and control bar.
 - **Own your audio** — download MP3 files, auto-embed them into your note, and keep an offline archive.
@@ -166,7 +166,7 @@ Configure your provider and credentials in **Settings → Voice**. The settings 
 
 | Setting                         | What it does                                                                                                                                                                                                                                                                              |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Speech Provider**             | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, or **OpenAI**. The credential fields below adapt to your choice.                                                                                                                                    |
+| **Speech Provider**             | Choose the engine: **AWS Polly**, **ElevenLabs**, **Google Cloud**, **Azure Speech**, **OpenAI**, or **Kokoro**. The credential fields below adapt to your choice.                                                                                                                        |
 | **Rewind interval**             | How many seconds the rewind control jumps back (1–60s, default 3s).                                                                                                                                                                                                                       |
 | **Fast-forward interval**       | How many seconds the fast-forward control jumps ahead (1–60s, default 3s).                                                                                                                                                                                                                |
 | **Save automatically**          | Automatically save and embed the MP3 after each playback. Off by default.                                                                                                                                                                                                                 |
@@ -200,14 +200,14 @@ Voice ships **16 commands** you can bind to any hotkey. No keys are assigned by 
 
 ## Bring Your Own Provider
 
-Voice is built to work with the provider you already use. For a long time it was AWS Polly only — the goal now is to support all the common text-to-speech engines, so you can bring your own. Pick **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, or **Azure Speech** from the **Speech Provider** dropdown in settings. Each provider keeps its own credentials and voice list; everything else — tempo, rewind/fast-forward intervals, downloads, auto-save, and the content toggles — works identically. After entering your credentials, press **Test Credentials** to confirm everything is connected.
+Voice is built to work with the provider you already use. For a long time it was AWS Polly only — the goal now is to support all the common text-to-speech engines, so you can bring your own. Pick **AWS Polly**, **ElevenLabs**, **OpenAI**, **Google Cloud**, **Azure Speech**, or self-hosted **Kokoro** from the **Speech Provider** dropdown in settings. Each provider keeps its own credentials and voice list; everything else — tempo, rewind/fast-forward intervals, downloads, auto-save, and the content toggles — works identically. After entering your credentials, press **Test Credentials** to confirm everything is connected. Kokoro runs locally, so it has no API key; just point it at your Kokoro-FastAPI server.
 
-|                 | **AWS Polly**                       | **ElevenLabs**                                      | **Google Cloud**                                  | **Azure Speech**                    | **OpenAI**                                    |
-| --------------- | ----------------------------------- | --------------------------------------------------- | ------------------------------------------------- | ----------------------------------- | --------------------------------------------- |
-| **Voices**      | Neural voices across many languages | Premade & multilingual voices speaking 29 languages | Neural2 & WaveNet voices across many languages    | Neural voices across many languages | Built-in multilingual voices (Alloy, Nova, …) |
-| **Credentials** | AWS region + Access Key ID & Secret | ElevenLabs API key                                  | Google Cloud API key (Text-to-Speech API enabled) | Azure Speech key + region           | OpenAI API key                                |
-| **Emphasis**    | Native SSML pauses & emphasis       | Expressive models with natural `<break>` pauses     | Native SSML pauses & emphasis                     | Native SSML pauses & emphasis       | Natural prosody (no SSML)                     |
-| **Models**      | Neural engine                       | Multilingual v2 / Flash v2.5 / Turbo v2.5           | Neural2 / WaveNet                                 | Neural                              | GPT-4o mini TTS / TTS-1 / TTS-1 HD            |
+|                 | **AWS Polly**                       | **ElevenLabs**                                      | **Google Cloud**                                  | **Azure Speech**                    | **OpenAI**                                    | **Kokoro**                                |
+| --------------- | ----------------------------------- | --------------------------------------------------- | ------------------------------------------------- | ----------------------------------- | --------------------------------------------- | ----------------------------------------- |
+| **Voices**      | Neural voices across many languages | Premade & multilingual voices speaking 29 languages | Neural2 & WaveNet voices across many languages    | Neural voices across many languages | Built-in multilingual voices (Alloy, Nova, …) | Curated open-weight voices                |
+| **Credentials** | AWS region + Access Key ID & Secret | ElevenLabs API key                                  | Google Cloud API key (Text-to-Speech API enabled) | Azure Speech key + region           | OpenAI API key                                | No key — runs on your own machine         |
+| **Emphasis**    | Native SSML pauses & emphasis       | Expressive models with natural `<break>` pauses     | Native SSML pauses & emphasis                     | Native SSML pauses & emphasis       | Natural prosody (no SSML)                     | Plain text; `<break>` tags stripped       |
+| **Models**      | Neural engine                       | Multilingual v2 / Flash v2.5 / Turbo v2.5           | Neural2 / WaveNet                                 | Neural                              | GPT-4o mini TTS / TTS-1 / TTS-1 HD            | `kokoro` (or model served by your server) |
 
 ## Getting Started
 
@@ -230,6 +230,14 @@ Start with the provider you already have — you can switch anytime.
 **Azure Speech** — In the [Azure portal](https://portal.azure.com/), create a **Speech** resource and copy a **Key** and **Region**. In **Settings → Voice**, choose **Azure Speech**, select the matching region, pick a voice, paste the key, and press **Test Credentials**.
 
 **OpenAI** — Create an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys). In **Settings → Voice**, choose **OpenAI**, pick a model and voice, paste the key, and press **Test Credentials**.
+
+**Kokoro** — Run a local [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI) server. The fastest way on a machine with a GPU is:
+
+```bash
+docker run --name kokoro-tts --gpus all -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-gpu:latest
+```
+
+For other install options (CPU, Docker Compose, manual install, etc.), see the [Kokoro-FastAPI repository](https://github.com/remsky/Kokoro-FastAPI). Once the server is running, in **Settings → Voice** choose **Kokoro (local)**, enter the base URL (default `http://localhost:8880`), pick a voice, and press **Test Credentials**. Kokoro has no API key because it runs on your own machine.
 
 ## Troubleshooting & Help
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voice",
-  "version": "1.16.3",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voice",
-      "version": "1.16.3",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "remark-frontmatter": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voice",
-  "version": "1.16.4",
+  "version": "1.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voice",
-      "version": "1.16.4",
+      "version": "1.16.3",
       "license": "MIT",
       "dependencies": {
         "remark-frontmatter": "^5.0.0",
@@ -18,12 +18,12 @@
       "devDependencies": {
         "@aws-sdk/client-polly": "3.1068.0",
         "@aws-sdk/credential-providers": "3.1068.0",
-        "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/js": "9.39.1",
         "@types/jest": "29.5.12",
-        "@types/mdast": "^4.0.4",
         "@types/node": "25.9.3",
         "@types/unist": "^3.0.3",
+        "@typescript-eslint/eslint-plugin": "8.46.3",
+        "@typescript-eslint/parser": "8.46.3",
         "esbuild": "0.28.1",
         "eslint": "9.39.1",
         "eslint-plugin-obsidianmd": "^0.3.0",
@@ -37,7 +37,7 @@
         "ts-jest": "29.4.11",
         "tslib": "2.8.1",
         "typescript": "5.9.3",
-        "typescript-eslint": "8.64.0"
+        "typescript-eslint": "8.46.3"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1804,40 +1804,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
-      "integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "ignore": "^7.0.5"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1854,9 +1824,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
-      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2998,20 +2968,21 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.3.tgz",
+      "integrity": "sha512-sbaQ27XBUopBkRiuY/P9sWGOWUW4rl8fDoHIUmLpZd8uldsTyB4/Zg6bWTegPoTLnKj9Hqgn3QD6cjPNB32Odw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/type-utils": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
-        "ignore": "^7.0.5",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.46.3",
+        "@typescript-eslint/type-utils": "8.46.3",
+        "@typescript-eslint/utils": "8.46.3",
+        "@typescript-eslint/visitor-keys": "8.46.3",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.5.0"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3021,15 +2992,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.64.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "@typescript-eslint/parser": "^8.46.3",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3037,17 +3008,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.3.tgz",
+      "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
-        "debug": "^4.4.3"
+        "@typescript-eslint/scope-manager": "8.46.3",
+        "@typescript-eslint/types": "8.46.3",
+        "@typescript-eslint/typescript-estree": "8.46.3",
+        "@typescript-eslint/visitor-keys": "8.46.3",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3057,20 +3028,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.3.tgz",
+      "integrity": "sha512-Fz8yFXsp2wDFeUElO88S9n4w1I4CWDTXDqDr9gYvZgUpwXQqmZBr9+NTTql5R3J7+hrJZPdpiWaB9VNhAKYLuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
-        "debug": "^4.4.3"
+        "@typescript-eslint/tsconfig-utils": "^8.46.3",
+        "@typescript-eslint/types": "^8.46.3",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3080,18 +3051,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.3.tgz",
+      "integrity": "sha512-FCi7Y1zgrmxp3DfWfr+3m9ansUUFoy8dkEdeQSgA9gbm8DaHYvZCdkFRQrtKiedFf3Ha6VmoqoAaP68+i+22kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0"
+        "@typescript-eslint/types": "8.46.3",
+        "@typescript-eslint/visitor-keys": "8.46.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3102,9 +3073,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.3.tgz",
+      "integrity": "sha512-GLupljMniHNIROP0zE7nCcybptolcH8QZfXOpCfhQDAdwJ/ZTlcaBOYebSOZotpti/3HrHSw7D3PZm75gYFsOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3115,21 +3086,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.3.tgz",
+      "integrity": "sha512-ZPCADbr+qfz3aiTTYNNkCbUt+cjNwI/5McyANNrFBpVxPt7GqpEYz5ZfdwuFyGUnJ9FdDXbGODUu6iRCI6XRXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.5.0"
+        "@typescript-eslint/types": "8.46.3",
+        "@typescript-eslint/typescript-estree": "8.46.3",
+        "@typescript-eslint/utils": "8.46.3",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3139,14 +3110,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.3.tgz",
+      "integrity": "sha512-G7Ok9WN/ggW7e/tOf8TQYMaxgID3Iujn231hfi0Pc7ZheztIJVpO44ekY00b7akqc6nZcvregk0Jpah3kep6hA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3158,21 +3129,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.3.tgz",
+      "integrity": "sha512-f/NvtRjOm80BtNM5OQtlaBdM5BRFUv7gf381j9wygDNL+qOYSNOgtQ/DCndiYi80iIOv76QqaTmp4fa9hwI0OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.64.0",
-        "@typescript-eslint/tsconfig-utils": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.5.0"
+        "@typescript-eslint/project-service": "8.46.3",
+        "@typescript-eslint/tsconfig-utils": "8.46.3",
+        "@typescript-eslint/types": "8.46.3",
+        "@typescript-eslint/visitor-keys": "8.46.3",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3182,59 +3154,46 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.3.tgz",
+      "integrity": "sha512-VXw7qmdkucEx9WkmR3ld/u6VhRyKeiF1uxWwCy/iuNfokjJ7VhsgLSOTjsol8BunSw190zABzpwdNsze2Kpo4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.46.3",
+        "@typescript-eslint/types": "8.46.3",
+        "@typescript-eslint/typescript-estree": "8.46.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3244,19 +3203,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.3.tgz",
+      "integrity": "sha512-uk574k8IU0rOF/AjniX8qbLSGURJVUCeM5e4MIMKBFFi8weeiLrG1fyQejyLXQpRZbU/1BuQasleV/RfHC3hHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "eslint-visitor-keys": "^5.0.0"
+        "@typescript-eslint/types": "8.46.3",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3267,13 +3226,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -6249,6 +6208,13 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -10962,54 +10928,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -11057,9 +10975,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11320,16 +11238,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
-      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
+      "version": "8.46.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.3.tgz",
+      "integrity": "sha512-bAfgMavTuGo+8n6/QQDVQz4tZ4f7Soqg53RbrlZQEoAltYop/XR4RAts/I0BrO3TTClTSTFJ0wYbla+P8cEWJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.64.0",
-        "@typescript-eslint/parser": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0"
+        "@typescript-eslint/eslint-plugin": "8.46.3",
+        "@typescript-eslint/parser": "8.46.3",
+        "@typescript-eslint/typescript-estree": "8.46.3",
+        "@typescript-eslint/utils": "8.46.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11339,8 +11257,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/uglify-js": {

--- a/src/service/AwsPollyService.ts
+++ b/src/service/AwsPollyService.ts
@@ -44,6 +44,7 @@ interface SynthesizeInput {
 
 export class AwsPollyService extends BaseSpeechService {
   readonly inputFormat = "ssml" as const;
+  readonly supportsBreakTags = false;
 
   private synthesizeInput: {
     Engine: Engine;

--- a/src/service/AzureSpeechService.ts
+++ b/src/service/AzureSpeechService.ts
@@ -28,6 +28,7 @@ const MAX_SSML_CHUNK_CHARS = 2500;
 
 export class AzureSpeechService extends BaseSpeechService {
   readonly inputFormat = "ssml" as const;
+  readonly supportsBreakTags = false;
 
   private apiKey: string;
   private region: string;

--- a/src/service/BaseSpeechService.ts
+++ b/src/service/BaseSpeechService.ts
@@ -49,6 +49,7 @@ export abstract class BaseSpeechService implements SpeechProvider {
   // --- Provider-specific members implemented by subclasses ---
 
   abstract readonly inputFormat: "ssml" | "text";
+  abstract readonly supportsBreakTags: boolean;
   abstract speak(
     content: string,
     speed?: number,

--- a/src/service/ElevenLabsService.ts
+++ b/src/service/ElevenLabsService.ts
@@ -28,6 +28,7 @@ const MAX_CHUNK_CHARS = 3000;
 
 export class ElevenLabsService extends BaseSpeechService {
   readonly inputFormat = "text" as const;
+  readonly supportsBreakTags = true;
 
   private apiKey: string;
   private model: string;

--- a/src/service/GoogleTtsService.ts
+++ b/src/service/GoogleTtsService.ts
@@ -39,6 +39,7 @@ function base64ToBytes(base64: string): Uint8Array {
 
 export class GoogleTtsService extends BaseSpeechService {
   readonly inputFormat = "ssml" as const;
+  readonly supportsBreakTags = false;
 
   private apiKey: string;
 

--- a/src/service/KokoroSpeechService.ts
+++ b/src/service/KokoroSpeechService.ts
@@ -1,6 +1,6 @@
 import { requestUrl } from "obsidian";
 import {
-  OPENAI_VOICES,
+  KOKORO_VOICES,
   type VoiceOption,
   type VoiceSettings,
 } from "../settings/VoiceSettings";
@@ -9,49 +9,58 @@ import type { CredentialValidationResult } from "./SpeechProvider";
 import { chunkPlainText } from "./textChunker";
 
 /**
- * OpenAI Text-to-Speech integration.
+ * Kokoro TTS integration (local or self-hosted via Kokoro-FastAPI).
  *
- * - Receives plain spoken text from TextSpeaker (OpenAI's speech endpoint does
- *   not support SSML, so the text pipeline is used instead of the SSML pipeline).
+ * - Receives plain spoken text from TextSpeaker (Kokoro accepts plain text).
  * - Chunks long notes to stay within the per-request input limit and
  *   concatenates the resulting MP3 blobs.
- * - Uses Obsidian's requestUrl() with a Bearer token to bypass browser CORS
- *   (same rationale as the other HTTP providers) and to keep the key out of
- *   fetch/XHR client requests.
- * - Playback/controls/caching are inherited from BaseSpeechService. Speed is
- *   applied client-side via the audio element, so it is not sent to the API.
+ * - Uses Obsidian's requestUrl() so the request works inside Obsidian's
+ *   sandboxed environment and avoids browser CORS issues.
+ * - No API key is required; the endpoint is assumed to be reachable on the
+ *   configured base URL (default http://localhost:8880).
  */
 
-const OPENAI_BASE_URL = "https://api.openai.com/v1";
-// Conservative per-request size. The speech endpoint accepts up to ~4096
-// characters; smaller chunks lower first-audio latency and stay safely under
-// the limit for every model.
+const DEFAULT_KOKORO_BASE_URL = "http://localhost:8880";
+// Kokoro-FastAPI is comfortable with a few thousand characters; keep a
+// conservative limit to avoid timeouts and to enable progress feedback.
 const MAX_CHUNK_CHARS = 2000;
 
-export class OpenAiSpeechService extends BaseSpeechService {
+export class KokoroSpeechService extends BaseSpeechService {
   readonly inputFormat = "text" as const;
-  readonly supportsBreakTags = true;
+  readonly supportsBreakTags = false;
 
-  private apiKey: string;
+  private baseUrl: string;
   private model: string;
+  private langCode: string;
 
-  constructor(apiKey: string, voice: string, model: string, speed?: number) {
+  constructor(
+    baseUrl: string,
+    voice: string,
+    model: string,
+    langCode: string,
+    speed?: number,
+  ) {
     super(voice, speed);
-    this.apiKey = apiKey;
-    this.model = model || "gpt-4o-mini-tts";
+    this.baseUrl = (baseUrl || DEFAULT_KOKORO_BASE_URL).replace(/\/$/, "");
+    this.model = model || "kokoro";
+    this.langCode = langCode || "p";
   }
 
   getVoiceOptions(): VoiceOption[] {
-    return OPENAI_VOICES;
+    return KOKORO_VOICES;
   }
 
   updateCredentials(settings: VoiceSettings): void {
-    this.apiKey = settings.OPENAI_API_KEY;
-    this.model = settings.OPENAI_MODEL || "gpt-4o-mini-tts";
+    this.baseUrl = (
+      settings.KOKORO_BASE_URL || DEFAULT_KOKORO_BASE_URL
+    ).replace(/\/$/, "");
+    this.voice = settings.KOKORO_VOICE;
+    this.model = settings.KOKORO_MODEL || "kokoro";
+    this.langCode = settings.KOKORO_LANG_CODE || "p";
   }
 
   /**
-   * Synthesize and play plain text via OpenAI.
+   * Synthesize and play plain text via a local Kokoro-FastAPI endpoint.
    */
   async speak(
     content: string,
@@ -59,13 +68,7 @@ export class OpenAiSpeechService extends BaseSpeechService {
     filePath?: string,
   ): Promise<void> {
     if (this.isLoading) {
-      throw new Error("OpenAI call already in progress.");
-    }
-
-    if (!this.apiKey) {
-      const error = new Error("Missing OpenAI API key");
-      this.reportError(error);
-      throw error;
+      throw new Error("Kokoro TTS call already in progress.");
     }
 
     const text = content.trim();
@@ -92,8 +95,6 @@ export class OpenAiSpeechService extends BaseSpeechService {
         }
 
         audioBlobs.push(blob);
-
-        // Reserve the last slice of the bar for concatenation + buffering.
         this.reportProgress(((i + 1) / chunks.length) * 0.95, 1);
       }
 
@@ -103,7 +104,7 @@ export class OpenAiSpeechService extends BaseSpeechService {
       if (error instanceof Error && error.name === "AbortError") {
         return;
       }
-      console.error("Error in OpenAI speak:", error);
+      console.error("Error in Kokoro speak:", error);
       this.reportError(error);
       throw error;
     } finally {
@@ -117,10 +118,9 @@ export class OpenAiSpeechService extends BaseSpeechService {
    */
   private async synthesizeChunk(text: string): Promise<Blob> {
     const response = await requestUrl({
-      url: `${OPENAI_BASE_URL}/audio/speech`,
+      url: `${this.baseUrl}/v1/audio/speech`,
       method: "POST",
       headers: {
-        Authorization: `Bearer ${this.apiKey}`,
         "Content-Type": "application/json",
         Accept: "audio/mpeg",
       },
@@ -128,21 +128,22 @@ export class OpenAiSpeechService extends BaseSpeechService {
         model: this.model,
         input: text,
         voice: this.voice,
+        lang_code: this.langCode,
         response_format: "mp3",
+        speed: 1.0,
       }),
       throw: false,
     });
 
-    if (response.status === 401) {
-      throw new Error("OpenAI: invalid or expired API key (401)");
-    }
-    if (response.status === 429) {
-      throw new Error("OpenAI: rate limit or quota reached (429)");
+    if (response.status === 404) {
+      throw new Error(
+        "Kokoro TTS endpoint not found. Is Kokoro running at the configured URL?",
+      );
     }
     if (response.status >= 400) {
-      const message = response.json?.error?.message;
+      const message = response.json?.error?.message || response.text;
       throw new Error(
-        `OpenAI API error (HTTP ${response.status})${
+        `Kokoro TTS error (HTTP ${response.status})${
           message ? `: ${message}` : ""
         }`,
       );
@@ -150,45 +151,42 @@ export class OpenAiSpeechService extends BaseSpeechService {
 
     const arrayBuffer = response.arrayBuffer;
     if (!arrayBuffer || arrayBuffer.byteLength === 0) {
-      throw new Error("OpenAI returned an empty audio response");
+      throw new Error("Kokoro returned an empty audio response");
     }
 
     return new Blob([arrayBuffer], { type: "audio/mpeg" });
   }
 
   /**
-   * Validate the API key. OpenAI has no list-voices endpoint, so we probe the
-   * models endpoint; a 200 means the key works. The voice count reflects the
-   * built-in catalog.
+   * Validate the Kokoro endpoint by probing the /v1/models route.
    */
   async validateCredentials(): Promise<CredentialValidationResult> {
-    if (!this.apiKey) {
-      return { isValid: false, error: "Please enter your OpenAI API key." };
-    }
-
     try {
       const response = await requestUrl({
-        url: `${OPENAI_BASE_URL}/models`,
+        url: `${this.baseUrl}/v1/models`,
         method: "GET",
-        headers: { Authorization: `Bearer ${this.apiKey}` },
         throw: false,
       });
 
       if (response.status === 200) {
-        return { isValid: true, voiceCount: OPENAI_VOICES.length };
+        return { isValid: true, voiceCount: KOKORO_VOICES.length };
       }
-      if (response.status === 401) {
-        return { isValid: false, error: "Invalid or expired OpenAI API key." };
+      if (response.status === 404) {
+        return {
+          isValid: false,
+          error: "Kokoro endpoint not found. Check the base URL.",
+        };
       }
       return {
         isValid: false,
         error: `Validation failed (HTTP ${response.status}).`,
       };
     } catch (error) {
-      console.error("OpenAI credential validation error:", error);
+      console.error("Kokoro credential validation error:", error);
       return {
         isValid: false,
-        error: "Network error during validation. Please try again.",
+        error:
+          "Could not reach Kokoro TTS. Make sure the server is running and reachable.",
       };
     }
   }
@@ -197,23 +195,17 @@ export class OpenAiSpeechService extends BaseSpeechService {
     if (error && typeof error === "object" && "message" in error) {
       const message = String((error as { message: string }).message);
 
-      if (message.includes("401")) {
-        return "Invalid OpenAI API key.";
-      }
-      if (message.includes("429")) {
-        return "OpenAI rate limit or quota reached. Please wait and try again.";
-      }
-      if (message.includes("Missing OpenAI API key")) {
-        return "Add your OpenAI API key in settings.";
+      if (message.includes("404")) {
+        return "Kokoro TTS endpoint not found. Check the base URL and make sure the server is running.";
       }
       if (message.includes("empty audio")) {
-        return "OpenAI returned no audio. Try a different voice or model.";
+        return "Kokoro returned no audio. Try a different voice or lang_code.";
       }
       if (message.toLowerCase().includes("network")) {
-        return "Connection failed. Check your internet.";
+        return "Connection failed. Check that Kokoro TTS is running.";
       }
-      return `OpenAI error: ${message}`;
+      return `Kokoro error: ${message}`;
     }
-    return "OpenAI error. Please try again.";
+    return "Kokoro TTS error. Please try again.";
   }
 }

--- a/src/service/SpeechProvider.ts
+++ b/src/service/SpeechProvider.ts
@@ -37,6 +37,12 @@ export interface SpeechProvider {
   readonly inputFormat: "ssml" | "text";
 
   /**
+   * Whether this provider understands ElevenLabs-style `<break time="..."/>`
+   * pause tags in plain-text input. When false, the text pipeline strips them.
+   */
+  readonly supportsBreakTags: boolean;
+
+  /**
    * Synthesize and play the given processed content.
    */
   speak(content: string, speed?: number, filePath?: string): Promise<void>;

--- a/src/service/SpeechProviderFactory.ts
+++ b/src/service/SpeechProviderFactory.ts
@@ -9,6 +9,7 @@ import { ElevenLabsService } from "./ElevenLabsService";
 import { GoogleTtsService } from "./GoogleTtsService";
 import { AzureSpeechService } from "./AzureSpeechService";
 import { OpenAiSpeechService } from "./OpenAiSpeechService";
+import { KokoroSpeechService } from "./KokoroSpeechService";
 
 /**
  * Create the speech provider selected in settings.
@@ -42,6 +43,14 @@ export function createSpeechProvider(settings: VoiceSettings): SpeechProvider {
       settings.OPENAI_API_KEY,
       settings.OPENAI_VOICE,
       settings.OPENAI_MODEL,
+      Number(settings.SPEED),
+    );
+  } else if (settings.TTS_PROVIDER === "kokoro") {
+    provider = new KokoroSpeechService(
+      settings.KOKORO_BASE_URL,
+      settings.KOKORO_VOICE,
+      settings.KOKORO_MODEL,
+      settings.KOKORO_LANG_CODE,
       Number(settings.SPEED),
     );
   } else {

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -4,6 +4,7 @@ import {
   ELEVENLABS_MODELS,
   AZURE_REGIONS,
   OPENAI_MODELS,
+  KOKORO_VOICES,
   MIN_SKIP_SECONDS,
   MAX_SKIP_SECONDS,
 } from "./VoiceSettings";
@@ -73,6 +74,7 @@ export class VoiceSettingTab extends PluginSettingTab {
           .addOption("google", "Google Cloud")
           .addOption("azure", "Azure Speech")
           .addOption("openai", "OpenAI")
+          .addOption("kokoro", "Kokoro (local)")
           .setValue(this.plugin.settings.TTS_PROVIDER)
           .onChange(async (value) => {
             this.plugin.settings.TTS_PROVIDER = value as
@@ -80,7 +82,8 @@ export class VoiceSettingTab extends PluginSettingTab {
               | "elevenlabs"
               | "google"
               | "azure"
-              | "openai";
+              | "openai"
+              | "kokoro";
             await this.plugin.saveSettings();
             // Swap the active provider and rewire the UI/orchestration
             this.plugin.reinitializeProvider();
@@ -194,6 +197,8 @@ export class VoiceSettingTab extends PluginSettingTab {
       this.displayAzureSettings(containerEl);
     } else if (this.plugin.settings.TTS_PROVIDER === "openai") {
       this.displayOpenAISettings(containerEl);
+    } else if (this.plugin.settings.TTS_PROVIDER === "kokoro") {
+      this.displayKokoroSettings(containerEl);
     } else {
       this.displayPollySettings(containerEl);
     }
@@ -241,6 +246,62 @@ export class VoiceSettingTab extends PluginSettingTab {
         "Enter your OpenAI API key above, then click 'Test Credentials' to validate",
       helpText: "Need an OpenAI API key? ",
       helpUrl: "https://platform.openai.com/api-keys",
+    });
+  }
+
+  private displayKokoroSettings(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("Kokoro TTS").setHeading();
+
+    this.addTextSetting(
+      containerEl,
+      "Base URL",
+      "The local Kokoro-FastAPI endpoint (e.g. http://localhost:8880).",
+      "http://localhost:8880",
+      this.plugin.settings.KOKORO_BASE_URL,
+      async (value) => {
+        this.plugin.settings.KOKORO_BASE_URL = value;
+        await this.plugin.saveSettings();
+        this.plugin.reinitializeProviderCredentials();
+      },
+    );
+
+    new Setting(containerEl)
+      .setName("Voice")
+      .setDesc("The Kokoro voice pack to use for synthesis.")
+      .addDropdown((dropdown) => {
+        KOKORO_VOICES.forEach((voice) => {
+          dropdown.addOption(voice.id, voice.label);
+        });
+        dropdown
+          .setValue(this.plugin.settings.KOKORO_VOICE)
+          .onChange(async (value) => {
+            this.plugin.settings.KOKORO_VOICE = value;
+            await this.plugin.saveSettings();
+            this.plugin.reinitializeProviderCredentials();
+          });
+      });
+
+    this.addTextSetting(
+      containerEl,
+      "Model",
+      "The model identifier sent to Kokoro (usually 'kokoro').",
+      "kokoro",
+      this.plugin.settings.KOKORO_MODEL,
+      async (value) => {
+        this.plugin.settings.KOKORO_MODEL = value;
+        await this.plugin.saveSettings();
+        this.plugin.reinitializeProviderCredentials();
+      },
+    );
+
+    this.renderCredentialValidation(containerEl, {
+      providerName: "Kokoro",
+      isConfigured: () => !!this.plugin.settings.KOKORO_BASE_URL,
+      missingMessage: "Please enter the Kokoro base URL before testing.",
+      promptMessage:
+        "Enter the Kokoro base URL above, then click 'Test Credentials' to validate",
+      helpText: "Need a local Kokoro server? ",
+      helpUrl: "https://github.com/remsky/Kokoro-FastAPI",
     });
   }
 
@@ -481,6 +542,25 @@ export class VoiceSettingTab extends PluginSettingTab {
               button.setTooltip(isVisible ? "Hide" : "Show");
             }
           });
+      });
+  }
+
+  /**
+   * Render a plain text setting (no password toggle).
+   */
+  private addTextSetting(
+    containerEl: HTMLElement,
+    name: string,
+    desc: string,
+    placeholder: string,
+    value: string,
+    onChange: (value: string) => Promise<void>,
+  ): void {
+    new Setting(containerEl)
+      .setName(name)
+      .setDesc(desc)
+      .addText((text) => {
+        text.setPlaceholder(placeholder).setValue(value).onChange(onChange);
       });
   }
 

--- a/src/settings/VoiceSettings.ts
+++ b/src/settings/VoiceSettings.ts
@@ -6,7 +6,8 @@ export type TtsProvider =
   | "elevenlabs"
   | "google"
   | "azure"
-  | "openai";
+  | "openai"
+  | "kokoro";
 
 /**
  * Where saved MP3s are written.
@@ -51,6 +52,12 @@ export interface VoiceSettings {
   OPENAI_API_KEY: string;
   OPENAI_VOICE: string;
   OPENAI_MODEL: string;
+
+  // Kokoro TTS (local / self-hosted)
+  KOKORO_BASE_URL: string;
+  KOKORO_VOICE: string;
+  KOKORO_LANG_CODE: string;
+  KOKORO_MODEL: string;
 
   // Content / speech options (shared across providers)
   spellOutAcronyms: boolean;
@@ -119,6 +126,22 @@ export interface ModelOption {
   label: string;
 }
 
+export interface KokoroLanguageOption {
+  id: string;
+  label: string;
+}
+
+export const KOKORO_LANGUAGES: KokoroLanguageOption[] = [
+  { id: "a", label: "American English" },
+  { id: "b", label: "British English" },
+  { id: "e", label: "Spanish" },
+  { id: "f", label: "French" },
+  { id: "h", label: "Hindi" },
+  { id: "i", label: "Italian" },
+  { id: "j", label: "Japanese" },
+  { id: "p", label: "Brazilian Portuguese" },
+  { id: "z", label: "Mandarin Chinese" },
+];
 export const VOICES: VoiceOption[] = [
   { id: "Stephen", label: "Stephen (American)", lang: "en-US" },
   { id: "Joanna", label: "Joanna (American)", lang: "en-US" },
@@ -347,6 +370,32 @@ export const OPENAI_VOICES: VoiceOption[] = [
   { id: "shimmer", label: "Shimmer (Soft)", lang: "en-US" },
 ];
 
+/**
+ * Kokoro voice pack selection. The `id` is the pack name accepted by
+ * Kokoro-FastAPI's /v1/audio/speech endpoint; `lang` reflects the language
+ * the pack speaks best.
+ */
+export const KOKORO_VOICES: VoiceOption[] = [
+  { id: "pm_alex", label: "Alex (Portuguese, Brazilian, Male)", lang: "pt-BR" },
+  {
+    id: "pf_dora",
+    label: "Dora (Portuguese, Brazilian, Female)",
+    lang: "pt-BR",
+  },
+  { id: "af_heart", label: "Heart (American, Female)", lang: "en-US" },
+  { id: "am_michael", label: "Michael (American, Male)", lang: "en-US" },
+  { id: "af_bella", label: "Bella (American, Female)", lang: "en-US" },
+  { id: "am_adam", label: "Adam (American, Male)", lang: "en-US" },
+  { id: "bf_emma", label: "Emma (British, Female)", lang: "en-GB" },
+  { id: "bm_george", label: "George (British, Male)", lang: "en-GB" },
+  { id: "jf_alpha", label: "Alpha (Japanese, Female)", lang: "ja-JP" },
+  { id: "jm_kumo", label: "Kumo (Japanese, Male)", lang: "ja-JP" },
+  { id: "ef_domi", label: "Domi (Spanish, Female)", lang: "es-ES" },
+  { id: "em_santa", label: "Santa (Spanish, Male)", lang: "es-ES" },
+  { id: "ff_siwis", label: "Siwis (French, Female)", lang: "fr-FR" },
+  { id: "if_sara", label: "Sara (Italian, Female)", lang: "it-IT" },
+];
+
 export const DEFAULT_SETTINGS: VoiceSettings = {
   TTS_PROVIDER: "polly",
 
@@ -370,6 +419,12 @@ export const DEFAULT_SETTINGS: VoiceSettings = {
   OPENAI_API_KEY: "",
   OPENAI_VOICE: "alloy",
   OPENAI_MODEL: "gpt-4o-mini-tts",
+
+  // Kokoro TTS defaults
+  KOKORO_BASE_URL: "http://localhost:8880",
+  KOKORO_VOICE: "pm_alex",
+  KOKORO_LANG_CODE: "p",
+  KOKORO_MODEL: "kokoro",
 
   spellOutAcronyms: false,
   readCodeBlocks: false,

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -8,6 +8,7 @@ import {
 } from "obsidian";
 import type { Voice } from "../utils/VoicePlugin";
 import type { TtsProvider } from "../settings/VoiceSettings";
+import { KOKORO_LANGUAGES } from "../settings/VoiceSettings";
 import { mp3FilesInFolder } from "../utils/folderAudio";
 import {
   chapterName,
@@ -35,6 +36,7 @@ const PROVIDERS: { id: TtsProvider; label: string }[] = [
   { id: "google", label: "Google Cloud" },
   { id: "azure", label: "Azure Speech" },
   { id: "openai", label: "OpenAI" },
+  { id: "kokoro", label: "Kokoro" },
 ];
 
 /**
@@ -68,6 +70,7 @@ export class VoicePlayerView extends ItemView {
   private downloadShowsSave = false;
   private providerSelect: HTMLSelectElement;
   private voiceSelect: HTMLSelectElement;
+  private kokoroLangSelect: HTMLSelectElement;
   private folderSelect: HTMLSelectElement;
   private codeBtn: HTMLElement;
   private acronymBtn: HTMLElement;
@@ -341,6 +344,21 @@ export class VoicePlayerView extends ItemView {
       this.changeVoice(this.voiceSelect.value),
     );
 
+    // Kokoro language code selector (only shown when Kokoro is active).
+    this.kokoroLangSelect = options.createEl("select", {
+      cls: "voice-player-select dropdown",
+      attr: { "aria-label": "Kokoro language" },
+    });
+    KOKORO_LANGUAGES.forEach((lang) =>
+      this.kokoroLangSelect.createEl("option", {
+        value: lang.id,
+        text: lang.label,
+      }),
+    );
+    this.registerDomEvent(this.kokoroLangSelect, "change", () =>
+      this.changeKokoroLanguage(this.kokoroLangSelect.value),
+    );
+
     // Folder picker: choose any vault folder that contains MP3s and list its
     // tracks as chapters, so the player can browse audio across the vault.
     const folderRow = root.createDiv({ cls: "voice-player-folder" });
@@ -565,6 +583,14 @@ export class VoicePlayerView extends ItemView {
     void this.plugin.persistActiveVoice(voiceId);
   }
 
+  /** Persist and apply the chosen Kokoro language code. */
+  private changeKokoroLanguage(langCode: string): void {
+    if (langCode === this.plugin.settings.KOKORO_LANG_CODE) {
+      return;
+    }
+    void this.plugin.persistKokoroLanguage(langCode);
+  }
+
   /** Toggle whether code blocks are read aloud. */
   private toggleCodeBlocks(): void {
     this.plugin.settings.readCodeBlocks = !this.plugin.settings.readCodeBlocks;
@@ -604,6 +630,9 @@ export class VoicePlayerView extends ItemView {
     }
     this.providerSelect.value = this.plugin.settings.TTS_PROVIDER;
     this.populateVoiceOptions();
+    this.kokoroLangSelect.value = this.plugin.settings.KOKORO_LANG_CODE;
+    this.kokoroLangSelect.style.display =
+      this.plugin.settings.TTS_PROVIDER === "kokoro" ? "" : "none";
     this.updateCodeButton();
     this.updateAcronymButton();
     this.updateUrlButton();

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -59,13 +59,17 @@ export class TextSpeaker {
       ...contentOptions,
     });
 
-    // Plain-text pipeline (ElevenLabs and other non-SSML providers). It also
-    // needs the acronym setting so it can title-case acronyms when spell-out is
-    // off, keeping pronunciation consistent with the SSML providers.
-    this.textProcessor = new MarkdownToTextProcessor({
-      ...contentOptions,
-      spellOutAcronyms: this.spellOutAcronyms,
-    });
+    // Plain-text pipeline (ElevenLabs, OpenAI, Kokoro). It also needs the
+    // acronym setting so it can title-case acronyms when spell-out is off,
+    // keeping pronunciation consistent with the SSML providers. Pause/break
+    // tags are only emitted when the provider understands them.
+    this.textProcessor = new MarkdownToTextProcessor(
+      {
+        ...contentOptions,
+        spellOutAcronyms: this.spellOutAcronyms,
+      },
+      { pauseTags: this.provider.supportsBreakTags },
+    );
   }
 
   async speakText(speed?: number): Promise<void> {

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -242,6 +242,17 @@ export class Voice extends Plugin {
   }
 
   /**
+   * Persist the chosen Kokoro language code, recreate the provider with the
+   * new lang_code, and refresh the player controls.
+   */
+  public async persistKokoroLanguage(langCode: string): Promise<void> {
+    this.settings.KOKORO_LANG_CODE = langCode;
+    await this.saveSettings();
+    this.reinitializeProvider();
+    this.refreshVoicePlayerControls();
+  }
+
+  /**
    * Apply the configured rewind/fast-forward skip intervals to the running
    * provider and refresh the control tooltips. Called when the user changes
    * the interval in settings (no audio interruption).

--- a/tests/kokoro.unit.test.ts
+++ b/tests/kokoro.unit.test.ts
@@ -1,0 +1,244 @@
+import { requestUrl } from "obsidian";
+import { KokoroSpeechService } from "../src/service/KokoroSpeechService";
+import { createSpeechProvider } from "../src/service/SpeechProviderFactory";
+import { DEFAULT_SETTINGS } from "../src/settings/VoiceSettings";
+
+const mockRequestUrl = requestUrl as jest.Mock;
+
+describe("Unit Tests - Kokoro Provider", () => {
+  beforeEach(() => {
+    mockRequestUrl.mockReset();
+  });
+
+  describe("Provider basics", () => {
+    test("declares the plain-text input format and no break-tag support", () => {
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+        1.0,
+      );
+      expect(service.inputFormat).toBe("text");
+      expect(service.supportsBreakTags).toBe(false);
+    });
+
+    test("exposes a non-empty voice catalog", () => {
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+      );
+      expect(service.getVoiceOptions().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Credential validation", () => {
+    test("probes /v1/models and reports the voice count when reachable", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        json: { data: [{ id: "kokoro" }] },
+      });
+
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+      );
+      const result = await service.validateCredentials();
+
+      expect(result.isValid).toBe(true);
+      expect(result.voiceCount).toBe(service.getVoiceOptions().length);
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.url).toBe("http://localhost:8880/v1/models");
+      expect(call.method).toBe("GET");
+    });
+
+    test("reports an error when the endpoint returns 404", async () => {
+      mockRequestUrl.mockResolvedValue({ status: 404 });
+
+      const service = new KokoroSpeechService(
+        "http://localhost:9999",
+        "pm_alex",
+        "kokoro",
+        "p",
+      );
+      const result = await service.validateCredentials();
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toMatch(/not found/i);
+    });
+
+    test("reports an error when the request fails", async () => {
+      mockRequestUrl.mockRejectedValue(new Error("Network error"));
+
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+      );
+      const result = await service.validateCredentials();
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toMatch(/could not reach/i);
+    });
+  });
+
+  describe("Synthesis", () => {
+    test("calls the speech endpoint with the right URL, headers and body", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(32),
+      });
+
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+        1.0,
+      );
+      await service.speak("Hello world.", 1.0, "note.md");
+
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.url).toBe("http://localhost:8880/v1/audio/speech");
+      expect(call.method).toBe("POST");
+      expect(call.headers["Content-Type"]).toBe("application/json");
+      expect(call.headers.Accept).toBe("audio/mpeg");
+
+      const body = JSON.parse(call.body);
+      expect(body.input).toBe("Hello world.");
+      expect(body.voice).toBe("pm_alex");
+      expect(body.model).toBe("kokoro");
+      expect(body.lang_code).toBe("p");
+      expect(body.response_format).toBe("mp3");
+      expect(body.speed).toBe(1.0);
+
+      // Audio should be cached for the active note (download support)
+      expect(service.getLastGeneratedAudio("note.md")).not.toBeNull();
+    });
+
+    test("chunks long text into multiple requests", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(16),
+      });
+
+      // ~3000 chars → exceeds the 2000 char chunk size
+      const longText = "word ".repeat(600).trim();
+
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+      );
+      await service.speak(longText);
+
+      expect(mockRequestUrl.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    test("throws and reports an error when the server returns 404", async () => {
+      mockRequestUrl.mockResolvedValue({ status: 404 });
+
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+      );
+      const errorCallback = jest.fn();
+      service.setErrorCallback(errorCallback);
+
+      await expect(service.speak("Hello")).rejects.toThrow();
+      expect(errorCallback).toHaveBeenCalled();
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    });
+
+    test("throws and reports an error when the server returns 400", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 400,
+        json: { error: { message: "Bad lang_code" } },
+      });
+
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+      );
+      const errorCallback = jest.fn();
+      service.setErrorCallback(errorCallback);
+
+      await expect(service.speak("Hello")).rejects.toThrow();
+      expect(errorCallback).toHaveBeenCalled();
+    });
+
+    test("throws when the audio response is empty", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(0),
+      });
+
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+      );
+
+      await expect(service.speak("Hello")).rejects.toThrow(/empty audio/i);
+    });
+  });
+
+  describe("Credentials update", () => {
+    test("applies new settings via updateCredentials", async () => {
+      mockRequestUrl.mockResolvedValue({
+        status: 200,
+        arrayBuffer: new ArrayBuffer(8),
+      });
+
+      const service = new KokoroSpeechService(
+        "http://localhost:8880",
+        "pm_alex",
+        "kokoro",
+        "p",
+      );
+      service.updateCredentials({
+        ...DEFAULT_SETTINGS,
+        KOKORO_BASE_URL: "http://kokoro.test/",
+        KOKORO_VOICE: "pf_dora",
+        KOKORO_MODEL: "kokoro-v1",
+        KOKORO_LANG_CODE: "e",
+      });
+
+      await service.speak("Hola.");
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.url).toBe("http://kokoro.test/v1/audio/speech");
+      const body = JSON.parse(call.body);
+      expect(body.voice).toBe("pf_dora");
+      expect(body.model).toBe("kokoro-v1");
+      expect(body.lang_code).toBe("e");
+    });
+  });
+});
+
+describe("Unit Tests - Speech Provider Factory (Kokoro)", () => {
+  test("creates a text provider for Kokoro", () => {
+    const provider = createSpeechProvider({
+      ...DEFAULT_SETTINGS,
+      TTS_PROVIDER: "kokoro",
+    });
+    expect(provider.inputFormat).toBe("text");
+    expect(provider.supportsBreakTags).toBe(false);
+    expect(provider.getVoiceOptions().some((v) => v.id === "pm_alex")).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for self-hosted **Kokoro-FastAPI** as a local text-to-speech provider, so users can listen to notes with an offline/local TTS engine without cloud credentials.

## Type of change

- [x] feat — new feature (minor)

## Changes

- Added `KokoroSpeechService` (`src/service/KokoroSpeechService.ts`) that calls a local Kokoro-FastAPI `/v1/audio/speech` endpoint and returns MP3 audio.
- Registered Kokoro in `SpeechProviderFactory` so it can be selected as the active provider.
- Added Kokoro settings: `KOKORO_BASE_URL`, `KOKORO_VOICE`, `KOKORO_LANG_CODE`, and `KOKORO_MODEL` (`src/settings/VoiceSettings.ts`).
- Added Kokoro to the provider dropdown in `VoiceSettingTab` with Base URL, voice picker, and model inputs.
- Added Kokoro to the player provider selector (`src/ui/VoicePlayerView.ts`).
- Added a Kokoro language-code selector directly in the player for quick language switching (`a`, `b`, `e`, `f`, `h`, `i`, `j`, `p`, `z`).
- Added `supportsBreakTags` capability to `SpeechProvider`/`BaseSpeechService` and implemented it per provider.
- Updated `TextSpeaker` to emit `<break>` pause tags only for providers that support them, preventing Kokoro from reading break tags aloud.
- Added unit tests for the Kokoro provider and factory (`tests/kokoro.unit.test.ts`).
- Updated `README.md` with Kokoro provider overview, installation instructions (Docker GPU), and setup steps.

## Provider impact

- [ ] None — no provider-specific behaviour changed
- [ ] AWS Polly
- [x] ElevenLabs — break-tag capability flag added; no functional change
- [x] OpenAI — break-tag capability flag added; no functional change
- [ ] Google Cloud
- [ ] Azure Speech

> Note: this PR also introduces a **new provider** (Kokoro).

## Platform impact

- [x] Desktop
- [x] Mobile (iOS / Android)

## How to test

1. Run a local Kokoro-FastAPI server, e.g. with Docker on a GPU machine:
   ```bash
   docker run --name kokoro-tts --gpus all -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-gpu:latest
   ```
   For other install options see [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI).
2. Open Obsidian Voice settings, select **Kokoro (local)** as the speech provider, and enter the Base URL.
3. Open a note and press play in the Voice player.
4. Verify audio is synthesized and played.
5. Use the language-code selector in the player to switch languages and verify synthesis still works.
6. Verify existing providers (OpenAI, ElevenLabs, etc.) still synthesize normally.
7. Run `npm test` — the new `tests/kokoro.unit.test.ts` exercises credential validation, synthesis, chunking, error paths and the factory.

## Checklist

- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm run lint:check` passes
- [x] `npm test` passes
- [x] Added/updated tests where it makes sense
- [x] Updated docs (README / TROUBLESHOOTING) if behaviour or settings changed
- [x] PR title follows Conventional Commits
- [x] No secrets/credentials committed

## Screenshots / recordings

<!-- For UI or player changes, before/after helps a lot. -->
