### PR TITLE
fix: comply with Obsidian scanner rules + gate them in CI on every branch

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/plugin-scan.yml
+++ b/.github/workflows/plugin-scan.yml
@@ -1,19 +1,23 @@
 name: Plugin Scan (Obsidian review parity)
 
-# Reproduces the checks the Obsidian community-hub automated review runs on each
-# release, so the same findings are flagged during the PR instead of after
-# release (avoiding a scorecard/review downgrade). Runs on every pull request
-# into main and on the working branches.
+# Reproduces the checks the Obsidian community-hub automated review runs, so the
+# same findings fail the branch/PR here instead of surfacing after release as a
+# review downgrade. This is the guard that was missing when the 1.16.4 review
+# failed: `npm run lint:check` now runs the same rule set the scanner uses —
+# eslint-plugin-obsidianmd, the eslint-comments meta-rules
+# (require-description + no-restricted-disable, which forbid silencing an
+# Obsidian rule) and the type-checked typescript-eslint rules
+# (no-deprecated / no-redundant-type-constituents / no-unnecessary-type-assertion).
+#
+# Runs on every pull request into main AND every push to any non-main branch, so
+# no feature/fix/chore branch can reach a release without passing the scan.
 on:
   pull_request:
     branches:
       - main
   push:
-    branches:
-      - "feature/*"
-      - "fix/*"
-      - "chore/*"
-      - "release/*"
+    branches-ignore:
+      - main
 
 jobs:
   scan:
@@ -21,14 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: package-lock.json
 
@@ -38,7 +42,7 @@ jobs:
       - name: Formatting
         run: npm run format:check
 
-      - name: Lint (Obsidian guidelines)
+      - name: Lint (Obsidian scanner parity — guidelines, disable directives, typed rules)
         run: npm run lint:check
 
       - name: CSS browser-feature compatibility (Obsidian baseline)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import globals from "globals";
 import tseslint from "typescript-eslint";
 import obsidianmd from "eslint-plugin-obsidianmd";
+import comments from "@eslint-community/eslint-plugin-eslint-comments";
 import { fileURLToPath } from "url";
 
 const rootDir = fileURLToPath(new URL(".", import.meta.url));
@@ -29,6 +30,23 @@ export default [
   // Obsidian community plugin guidelines — the same ruleset the official
   // plugin scanner uses. Keeps releases free of the flagged API/CSS issues.
   ...obsidianmd.configs.recommended,
+  // Scanner parity for eslint-disable directives. The community scorecard
+  // rejects (a) any disable that lacks an inline `-- reason` description and
+  // (b) disabling its own rules at all. Suppressing an Obsidian rule instead of
+  // fixing the code is exactly what turned warnings into blocking errors on the
+  // 1.16.4 review, so make both a local/CI failure.
+  {
+    files: ["**/*.{js,mjs,cjs,ts}"],
+    plugins: { "@eslint-community/eslint-comments": comments },
+    rules: {
+      "@eslint-community/eslint-comments/require-description": "error",
+      "@eslint-community/eslint-comments/no-restricted-disable": [
+        "error",
+        "obsidianmd/*",
+        "@typescript-eslint/no-deprecated",
+      ],
+    },
+  },
   {
     files: ["**/*.ts"],
     rules: {
@@ -48,6 +66,12 @@ export default [
       // reasonably current, and treat a sudden drop in findings after a
       // downgrade as a red flag rather than a fix.
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
+      // Scanner parity: these type-checked rules are what the community
+      // scorecard reports. no-redundant-type-constituents catches a union
+      // component that resolved to TS's `error`/`any` type; no-deprecated
+      // catches use of APIs marked @deprecated in the Obsidian typings.
+      "@typescript-eslint/no-redundant-type-constituents": "error",
+      "@typescript-eslint/no-deprecated": "error",
       // Disabled deliberately:
       // - ui/sentence-case rewrites proper nouns/brand names incorrectly
       //   (e.g. "ElevenLabs" -> "Elevenlabs", AWS region names) and is not a

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "voice",
   "name": "Voice",
   "version": "1.16.4",
-  "minAppVersion": "1.5.0",
+  "minAppVersion": "1.7.2",
   "description": "Listen to your notes as natural speech with text-to-speech (TTS). Read notes aloud, play them like an audiobook in the voice player, download MP3 audio and listen offline hands-free on mobile.",
   "author": "Chris Oguntolu",
   "authorUrl": "https://github.com/chrisurf",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voice",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voice",
-      "version": "1.16.3",
+      "version": "1.16.4",
       "license": "MIT",
       "dependencies": {
         "remark-frontmatter": "^5.0.0",
@@ -18,8 +18,10 @@
       "devDependencies": {
         "@aws-sdk/client-polly": "3.1068.0",
         "@aws-sdk/credential-providers": "3.1068.0",
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/js": "9.39.1",
         "@types/jest": "29.5.12",
+        "@types/mdast": "^4.0.4",
         "@types/node": "25.9.3",
         "@types/unist": "^3.0.3",
         "esbuild": "0.28.1",
@@ -1800,6 +1802,36 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+      "integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "ignore": "^7.0.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -68,8 +68,10 @@
   "devDependencies": {
     "@aws-sdk/client-polly": "3.1068.0",
     "@aws-sdk/credential-providers": "3.1068.0",
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@eslint/js": "9.39.1",
     "@types/jest": "29.5.12",
+    "@types/mdast": "^4.0.4",
     "@types/node": "25.9.3",
     "@types/unist": "^3.0.3",
     "esbuild": "0.28.1",

--- a/src/processors/pipeline/SSMLValidator.ts
+++ b/src/processors/pipeline/SSMLValidator.ts
@@ -11,27 +11,8 @@
 import type { ValidationResult } from "../../types/ProcessorTypes";
 
 /**
- * Tags supported by AWS Polly Neural voices
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const NEURAL_SUPPORTED_TAGS = [
-  "speak",
-  "break",
-  "lang",
-  "mark",
-  "p",
-  "s",
-  "say-as",
-  "sub",
-  "w",
-  "prosody",
-  "phoneme",
-];
-
-/**
  * Tags NOT supported by Neural voices (reserved for future use)
  */
-
 const NEURAL_UNSUPPORTED_TAGS = [
   "emphasis", // Not supported for neural
   "amazon:auto-breaths",

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -48,6 +48,15 @@ export class VoiceSettingTab extends PluginSettingTab {
   }
 
   display(): void {
+    // display() is deprecated since Obsidian 1.13 in favour of
+    // getSettingDefinitions(), but this tab needs imperative rendering for its
+    // custom credential panels and dynamic provider switching. It stays as the
+    // required override; all (re-)rendering routes through render() so we never
+    // call the deprecated method ourselves.
+    this.render();
+  }
+
+  private render(): void {
     const { containerEl } = this;
     containerEl.empty();
 
@@ -76,12 +85,7 @@ export class VoiceSettingTab extends PluginSettingTab {
             // Swap the active provider and rewire the UI/orchestration
             this.plugin.reinitializeProvider();
             // Re-render so provider-specific fields and voices update.
-            // display() is the settings-tab refresh hook; the 1.13
-            // getSettingDefinitions API cannot express this tab's custom
-            // credential-validation panel and dynamic provider switching, so
-            // we intentionally keep using it.
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            this.display();
+            this.render();
           });
       });
 

--- a/src/ui/VoicePlayerView.ts
+++ b/src/ui/VoicePlayerView.ts
@@ -929,7 +929,7 @@ export class VoicePlayerView extends ItemView {
 
     // Close on outside click / Escape. Deferred so the opening click finishes.
     const onDocClick = (evt: MouseEvent) => {
-      if (!bar.contains(evt.target as Node)) {
+      if (!(evt.target instanceof Node) || !bar.contains(evt.target)) {
         this.closeChapterActions();
       }
     };
@@ -999,9 +999,8 @@ export class VoicePlayerView extends ItemView {
     const file = this.app.vault.getAbstractFileByPath(chapter.path);
     if (file instanceof TFile) {
       try {
-        // fileManager.trashFile() needs a newer Obsidian than minAppVersion.
-        // eslint-disable-next-line obsidianmd/prefer-file-manager-trash-file
-        await this.app.vault.delete(file);
+        // Move to the user's preferred trash (system bin or .trash).
+        await this.app.fileManager.trashFile(file);
         new Notice(`Deleted: ${chapter.name}`);
       } catch (error) {
         new Notice(

--- a/src/utils/AudioFileManager.ts
+++ b/src/utils/AudioFileManager.ts
@@ -107,10 +107,9 @@ export class AudioFileManager {
     }
     const existing = this.app.vault.getAbstractFileByPath(finalPath);
     if (existing instanceof TFile && existing.path !== source.path) {
-      // fileManager.trashFile() would be preferable but requires a newer
-      // Obsidian than the plugin's minAppVersion (1.5.0).
-      // eslint-disable-next-line obsidianmd/prefer-file-manager-trash-file
-      await this.app.vault.delete(existing);
+      // Move to the user's preferred trash (system bin or .trash) instead of
+      // deleting outright.
+      await this.app.fileManager.trashFile(existing);
     }
     // fileManager.renameFile updates embeds/links that point at the file.
     await this.app.fileManager.renameFile(source, finalPath);

--- a/src/utils/VoicePlugin.ts
+++ b/src/utils/VoicePlugin.ts
@@ -286,9 +286,8 @@ export class Voice extends Plugin {
         active: true,
       });
     }
-    // revealLeaf is the standard reveal API; it is a no-op on app versions
-    // that predate it, so we don't raise the manifest's minAppVersion floor.
-    // eslint-disable-next-line obsidianmd/no-unsupported-api
+    // Awaiting revealLeaf ensures the view is fully loaded (not deferred);
+    // it is available from the manifest's minAppVersion (1.7.2).
     await workspace.revealLeaf(leaf);
 
     // The player replaces the compact mobile bar; hide the bar so they are

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2018",
     "allowJs": true,
     "noImplicitAny": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Summary

The 1.16.4 community review **Failed** with source-code **Errors**. Root cause: the plugin carried five `eslint-disable` directives that silenced Obsidian's own lint rules so local `npm run lint:check` stayed green. The scanner forbids that — every disable needs an inline description, and `obsidianmd/*` / `@typescript-eslint/no-deprecated` may not be disabled at all — so once Obsidian tightened its scanner, the suppressions became **blocking errors**. Reverting to 1.16.2 would **not** help — the same directives existed there and would fail today too.

This fixes every finding at its root, removes all suppressions, and makes CI reproduce the scanner on **every branch** so it can't recur.

## Type of change

- [x] fix — bug fix (patch)
- [ ] feat / docs / refactor / chore
- [ ] BREAKING CHANGE

## Every review finding, addressed

**Errors (were blocking):**
- `prefer-file-manager-trash-file` — `vault.delete` → `fileManager.trashFile` (AudioFileManager, VoicePlayerView).
- `no-unsupported-api` — awaited `revealLeaf` is `@since 1.7.2`, `trashFile` `@since 1.6.6`; raise **minAppVersion 1.5.0 → 1.7.2** so both APIs are genuinely supported.
- `no-deprecated` — `PluginSettingTab.display()` is deprecated since 1.13; extract the body into `render()` and route re-renders through it.
- `no-unused-vars` — delete the dead `NEURAL_SUPPORTED_TAGS` constant.

**Warnings:**
- "error type acts as any" (6×) + the mdast "unnecessary assertion" (3×) — root cause was `moduleResolution: "bundler"` (needs TS 5.0+); when the scanner type-checks without honouring it, `obsidian`/`mdast` external types resolve to `any` so every union with them is flagged. Switch to **`moduleResolution: "node"`** (universally supported, the Obsidian sample-plugin convention) + declare **`@types/mdast`**.
- `evt.target as Node` → `instanceof Node` guard.

**Already resolved earlier (confirmed absent from the 1.16.4 scan):** DefaultConfig/AwsPollyService assertion warnings (#74), the css-masks CSS warning, and the 1.16.3 "build output does not match" (npm-only lockfile).

## Prevent recurrence — scanner parity locally AND in CI

- eslint config: add `@eslint-community/eslint-comments` (`require-description` + `no-restricted-disable` for `obsidianmd/*` and `no-deprecated`) plus `no-redundant-type-constituents` / `no-deprecated`. Verified it reproduces the exact scanner messages.
- `plugin-scan.yml` now runs on **every push to any non-main branch** and every PR into main; `npm run lint:check` is the parity gate. Node 24 / actions v5 across scan + feature workflows.

## Compatibility note

`minAppVersion` → **1.7.2** drops support for Obsidian 1.5.0–1.7.1 (all >1 year old). `versions.json` updates automatically at release; users on older apps stay on their current version.

## Non-blocking items deliberately left (never failed the review)

- `getSettingDefinitions()` — a **Recommendation**; the declarative API can't express this tab's custom credential panels / dynamic provider switching, and can't be verified without the Obsidian runtime.
- Vault Enumeration — an informational **Recommendation** inherent to the chapter/folder features. Present in every previously-**passing** review.

## How to test

1. `npm run build && npm run lint:check && npm run lint:css && npm test && npm run format:check` — all green (165 tests).
2. Add a `// eslint-disable-next-line obsidianmd/...` anywhere → `npm run lint:check` and the Scan job now fail with the scanner's message.
3. Delete a chapter / overwrite on move → file goes to the configured trash. Switch speech provider in settings → tab re-renders, no deprecation.

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint:check` passes (scanner-parity meta-rules)
- [x] `npm test` passes (165)
- [x] `npm run format:check` passes
- [x] No secrets committed
