### PR TITLE
chore: add Buy Me a Coffee funding (GitHub Sponsor button + Obsidian donate link)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Funding sources for the repository's "Sponsor" button.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+# `buy_me_a_coffee` takes the username only (from https://buymeacoffee.com/chrisurf).
+buy_me_a_coffee: chrisurf

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Turn every note into a mobile-friendly, audiobook-like experience. The Obsidian 
 - [Getting Started](#getting-started)
 - [Connecting a Provider](#connecting-a-provider)
 - [Troubleshooting & Help](#troubleshooting--help)
+- [Support](#support)
 
 ## Highlights
 
@@ -234,3 +235,11 @@ Start with the provider you already have — you can switch anytime.
 ## Troubleshooting & Help
 
 Run into an error, see a red control bar, or need the advanced provider setup (like creating a dedicated AWS user or picking the best region)? Everything is collected in the **[Troubleshooting & Advanced Setup guide](./TROUBLESHOOTING.md)**.
+
+## Support
+
+Voice is free and open source, built and maintained in my spare time. If it makes listening to your notes easier, you can support continued development with a coffee — it's genuinely appreciated. ☕
+
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-chrisurf-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/chrisurf)
+
+You'll also find a **Sponsor** button at the top of the [GitHub repository](https://github.com/chrisurf/obsidian-voice) and a donate link on the plugin's page inside Obsidian.

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,8 @@
   "description": "Listen to your notes as natural speech with text-to-speech (TTS). Read notes aloud, play them like an audiobook in the voice player, download MP3 audio and listen offline hands-free on mobile.",
   "author": "Chris Oguntolu",
   "authorUrl": "https://github.com/chrisurf",
+  "fundingUrl": {
+    "Buy Me a Coffee": "https://buymeacoffee.com/chrisurf"
+  },
   "isDesktopOnly": false
 }


### PR DESCRIPTION
## Summary

Wires the Buy Me a Coffee profile (`buymeacoffee.com/chrisurf`) through **both** platforms' official, native funding integrations — no custom UI needed.

## Type of change

- [ ] fix — bug fix (patch)
- [ ] feat — new feature (minor)
- [ ] docs — documentation only
- [x] refactor / chore — no user-facing code change
- [ ] BREAKING CHANGE

## Changes

- **`.github/FUNDING.yml`** — `buy_me_a_coffee: chrisurf`. GitHub renders its built-in **Sponsor** button on the repository from this file (GitHub added official Buy Me a Coffee support in 2024).
- **`manifest.json` → `fundingUrl`** — Obsidian shows a **donate link** on the plugin's community page and in the installed-plugin settings. Uses the labelled object form `{ "Buy Me a Coffee": "https://buymeacoffee.com/chrisurf" }` so the link is clearly named and easy to extend with more platforms later. The release pipeline only rewrites `.version`, so this static field is preserved across releases.
- **`README.md`** — a short **Support** section with a Buy Me a Coffee badge, plus a TOC entry.

## Provider impact

- [x] None — no provider-specific behaviour changed

## Platform impact

- [x] Desktop
- [x] Mobile (iOS / Android)

_No runtime code touched; funding metadata + docs only._

## How to test

1. `.github/FUNDING.yml` is valid YAML and `manifest.json` is valid JSON (verified locally); `npm run build` and `npm run format:check` pass.
2. After merge to `main`, the repository shows a **Sponsor** button (GitHub reads `FUNDING.yml` from the default branch; if it doesn't appear, check **Settings → General → Features → Sponsorships**).
3. Obsidian shows a donate link on the plugin page / settings from `fundingUrl` on the next release.

## Checklist

- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm run lint:check` passes
- [x] `npm test` passes
- [x] Updated docs (README) where behaviour or metadata changed
- [x] PR title follows Conventional Commits
- [x] No secrets/credentials committed

## Notes

The GitHub Sponsor button only appears once `FUNDING.yml` is on the default branch (i.e. after this merges).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SyFh958nxJcV1SgxvsUxyh)_