### PR TITLE
fix(azure): 2x-speed prosody rate + fix(player): visible play-button hold ring

### DIFF
--- a/src/service/AzureSpeechService.ts
+++ b/src/service/AzureSpeechService.ts
@@ -7,6 +7,7 @@ import {
 import { BaseSpeechService } from "./BaseSpeechService";
 import type { CredentialValidationResult } from "./SpeechProvider";
 import { mapAzureVoices } from "./voiceCatalog";
+import { adaptProsodyForAzure } from "./azureSsml";
 
 /**
  * Azure AI Speech (Cognitive Services) Text-to-Speech integration.
@@ -247,22 +248,14 @@ export class AzureSpeechService extends BaseSpeechService {
   }
 
   /**
-   * Wrap the pipeline's inner SSML in Azure's required envelope and adjust the
-   * one incompatible attribute: Azure prosody volume does not accept decibels,
-   * so map `volume="±NdB"` to a bounded relative percentage.
+   * Wrap the pipeline's inner SSML in Azure's required envelope and adapt the
+   * prosody attributes Azure interprets differently (rate + volume) — see
+   * adaptProsodyForAzure().
    */
   private toAzureSsml(ssml: string): string {
-    const inner = ssml
-      .replace(/^\s*<speak[^>]*>/, "")
-      .replace(/<\/speak>\s*$/, "")
-      .replace(/volume="([+-]?\d+(?:\.\d+)?)dB"/g, (_match, db: string) => {
-        const pct = Math.max(
-          -50,
-          Math.min(50, Math.round(parseFloat(db) * 10)),
-        );
-        const sign = pct >= 0 ? "+" : "";
-        return `volume="${sign}${pct}%"`;
-      });
+    const inner = adaptProsodyForAzure(
+      ssml.replace(/^\s*<speak[^>]*>/, "").replace(/<\/speak>\s*$/, ""),
+    );
 
     const locale = this.languageCode();
     return (

--- a/src/service/azureSsml.ts
+++ b/src/service/azureSsml.ts
@@ -1,0 +1,64 @@
+/**
+ * Azure-specific SSML adaptations.
+ *
+ * The content pipeline emits one "canonical" SSML dialect, flavoured for AWS
+ * Polly. Azure departs from that dialect in two prosody attributes, so every
+ * SSML chunk is adapted here before it is sent. Keeping the rules in pure,
+ * unit-tested functions (rather than inline in the service) means a provider
+ * incompatibility can be locked down with a test instead of being rediscovered
+ * in the audio.
+ *
+ * - `rate`: Azure reads a BARE percentage as RELATIVE — `rate="95%"` is treated
+ *   as `+95%` (≈ 1.95×), which made Azure read headings/emphasis at roughly
+ *   double speed (issues #56 and #77). The pipeline means the percentage
+ *   absolutely (95% = 0.95×, i.e. slightly slower), matching the SSML standard
+ *   and AWS Polly / Google. So an unsigned absolute percentage is converted to
+ *   the equivalent signed relative value (`95%` → `-5%`). Already-signed
+ *   percentages and keyword/multiplier values are left untouched.
+ * - `volume`: Azure prosody does not accept decibels; map `volume="±NdB"` to a
+ *   bounded relative percentage.
+ */
+
+const RATE_ATTR = /rate="([^"]*)"/g;
+const VOLUME_DB_ATTR = /volume="([+-]?\d+(?:\.\d+)?)dB"/g;
+const UNSIGNED_PERCENT = /^(\d+(?:\.\d+)?)%$/;
+
+/**
+ * Convert a single prosody `rate` value to the form Azure interprets correctly.
+ * An unsigned absolute percentage (the pipeline's output, e.g. "95%") becomes
+ * the equivalent signed relative percentage ("-5%"); a signed percentage,
+ * keyword (slow/fast/…) or bare multiplier passes through unchanged.
+ */
+export function azureProsodyRate(value: string): string {
+  const match = UNSIGNED_PERCENT.exec(value.trim());
+  if (!match) {
+    return value;
+  }
+  const relative = Math.round((parseFloat(match[1]) - 100) * 100) / 100;
+  return `${relative >= 0 ? "+" : ""}${relative}%`;
+}
+
+/**
+ * Map a prosody `volume` in decibels to Azure's bounded relative percentage.
+ */
+export function azureProsodyVolumeDb(db: number): string {
+  const pct = Math.max(-50, Math.min(50, Math.round(db * 10)));
+  return `${pct >= 0 ? "+" : ""}${pct}%`;
+}
+
+/**
+ * Apply every Azure prosody adaptation to a chunk of inner SSML (the content
+ * between <speak>…</speak>, before Azure's envelope is added).
+ */
+export function adaptProsodyForAzure(inner: string): string {
+  return inner
+    .replace(
+      VOLUME_DB_ATTR,
+      (_match, db: string) =>
+        `volume="${azureProsodyVolumeDb(parseFloat(db))}"`,
+    )
+    .replace(
+      RATE_ATTR,
+      (_match, value: string) => `rate="${azureProsodyRate(value)}"`,
+    );
+}

--- a/styles.css
+++ b/styles.css
@@ -1002,6 +1002,42 @@
   pointer-events: none;
 }
 
+/* The player's primary play button is itself accent-coloured, so the shared
+   accent sweep above is nearly invisible on it (accent on accent, 30% opacity).
+   Give this one button a thicker, high-contrast ring in the on-accent colour:
+   a faint full "track" (::before) plus a crisp sweep (::after) that grows to a
+   full circle as the regenerate-hold completes. Both sit BEHIND the opaque
+   button (z-index: -1) so only the ring protrudes and the icon is never washed
+   over. The press scale is dropped while holding so the button doesn't spawn a
+   stacking context (which would pull the ring in front of its own background).
+   No CSS mask/clip-path — those are only partially supported per stylelint. */
+.voice-player-play.voice-pressing {
+  transform: none;
+}
+
+.voice-player-play.voice-pressing::before,
+.voice-player-play.voice-pressing::after {
+  content: "";
+  position: absolute;
+  inset: -5px;
+  z-index: -1;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.voice-player-play.voice-pressing::before {
+  background: var(--text-on-accent);
+  opacity: 0.25;
+}
+
+.voice-player-play.voice-pressing::after {
+  background: conic-gradient(
+    var(--text-on-accent) calc(var(--press, 0) * 360deg),
+    transparent 0deg
+  );
+  opacity: 0.95;
+}
+
 /* File-conflict modal: the ".mp3" suffix shown next to the rename field. */
 .voice-conflict-ext {
   margin-left: 6px;

--- a/styles.css
+++ b/styles.css
@@ -1038,6 +1038,20 @@
   opacity: 0.95;
 }
 
+/* On light themes the on-accent colour is white, which vanishes on the light
+   pane. Swap the ring to the theme's dark ink so it contrasts with both the
+   accent button and the light background. */
+.theme-light .voice-player-play.voice-pressing::before {
+  background: var(--text-normal);
+}
+
+.theme-light .voice-player-play.voice-pressing::after {
+  background: conic-gradient(
+    var(--text-normal) calc(var(--press, 0) * 360deg),
+    transparent 0deg
+  );
+}
+
 /* File-conflict modal: the ".mp3" suffix shown next to the rename field. */
 .voice-conflict-ext {
   margin-left: 6px;

--- a/tests/azure.unit.test.ts
+++ b/tests/azure.unit.test.ts
@@ -2,8 +2,24 @@ import { requestUrl } from "obsidian";
 import { AzureSpeechService } from "../src/service/AzureSpeechService";
 import { createSpeechProvider } from "../src/service/SpeechProviderFactory";
 import { DEFAULT_SETTINGS } from "../src/settings/VoiceSettings";
+import {
+  azureProsodyRate,
+  azureProsodyVolumeDb,
+  adaptProsodyForAzure,
+} from "../src/service/azureSsml";
 
 const mockRequestUrl = requestUrl as jest.Mock;
+
+// A representative slice of the SSML the content pipeline produces for a heading
+// ("# Big heading") followed by an *emphasised* word: headings get a `loud`
+// volume + a slightly-slower `rate="98%"`, italics get `rate="95%"`. These are
+// absolute percentages (SSML/Polly/Google semantics). Kept as a fixture because
+// the real pipeline pulls in ESM-only `unified`, which the Jest (ts-jest)
+// runtime cannot import.
+const PIPELINE_SSML =
+  '<speak><prosody volume="loud" rate="98%">Big heading</prosody>' +
+  '<break time="800ms"/> Some <prosody rate="95%">emphasised</prosody> words.' +
+  "</speak>";
 
 describe("Unit Tests - Azure Speech Provider", () => {
   beforeEach(() => {
@@ -173,6 +189,109 @@ describe("Unit Tests - Azure Speech Provider", () => {
         expect.stringMatching(/invalid/i),
       );
     });
+  });
+});
+
+describe("Unit Tests - Azure SSML adaptation (rate/volume)", () => {
+  describe("azureProsodyRate", () => {
+    test("converts an unsigned absolute percentage to signed relative", () => {
+      // The pipeline emits absolute percentages (95% = 0.95x). Azure reads a
+      // bare percentage as relative (+95% ≈ 1.95x — the #56/#77 bug), so the
+      // intended slight slowdown must be expressed as a signed relative value.
+      expect(azureProsodyRate("95%")).toBe("-5%");
+      expect(azureProsodyRate("98%")).toBe("-2%");
+      expect(azureProsodyRate("100%")).toBe("+0%");
+      expect(azureProsodyRate("120%")).toBe("+20%");
+    });
+
+    test("handles decimal percentages", () => {
+      expect(azureProsodyRate("97.5%")).toBe("-2.5%");
+    });
+
+    test("leaves already-signed percentages, keywords and multipliers untouched", () => {
+      expect(azureProsodyRate("+10%")).toBe("+10%");
+      expect(azureProsodyRate("-15%")).toBe("-15%");
+      expect(azureProsodyRate("slow")).toBe("slow");
+      expect(azureProsodyRate("x-fast")).toBe("x-fast");
+      expect(azureProsodyRate("0.95")).toBe("0.95");
+    });
+  });
+
+  describe("azureProsodyVolumeDb", () => {
+    test("maps dB to a bounded relative percentage", () => {
+      expect(azureProsodyVolumeDb(2)).toBe("+20%");
+      expect(azureProsodyVolumeDb(-3)).toBe("-30%");
+      expect(azureProsodyVolumeDb(100)).toBe("+50%"); // clamped to ±50%
+    });
+  });
+
+  describe("adaptProsodyForAzure", () => {
+    test("rewrites rate and volume together, leaving text intact", () => {
+      const inner =
+        '<prosody volume="+2dB" rate="98%">Title</prosody> and ' +
+        '<prosody rate="95%">emphasis</prosody>';
+      const out = adaptProsodyForAzure(inner);
+      expect(out).toContain('rate="-2%"');
+      expect(out).toContain('rate="-5%"');
+      expect(out).toContain('volume="+20%"');
+      expect(out).toContain("Title");
+      expect(out).toContain("emphasis");
+      // No bare (unsigned) percentage rate — the exact thing Azure misreads.
+      expect(out).not.toMatch(/rate="\d/);
+      expect(out).not.toContain("dB");
+    });
+  });
+});
+
+describe("Unit Tests - Azure prosody rate regression (issues #56 / #77)", () => {
+  beforeEach(() => {
+    mockRequestUrl.mockReset();
+  });
+
+  test("never sends a bare percentage rate to Azure", async () => {
+    mockRequestUrl.mockResolvedValue({
+      status: 200,
+      arrayBuffer: new ArrayBuffer(8),
+    });
+    const service = new AzureSpeechService(
+      "key",
+      "eastus",
+      "en-US-JennyNeural",
+    );
+    await service.speak(
+      '<speak><prosody rate="98%">Heading</prosody> ' +
+        '<prosody rate="95%">italic</prosody></speak>',
+    );
+    const body = mockRequestUrl.mock.calls[0][0].body as string;
+    expect(body).toContain('rate="-2%"');
+    expect(body).toContain('rate="-5%"');
+    // Guard the actual defect: no unsigned absolute percentage reaches Azure.
+    expect(body).not.toMatch(/rate="\d/);
+  });
+
+  test("golden: representative pipeline SSML never leaks a bare-% rate into Azure", async () => {
+    // The canonical pipeline output intentionally uses absolute percentages
+    // (SSML/Polly/Google semantics) — this documents the divergence…
+    expect(PIPELINE_SSML).toMatch(/rate="\d+(?:\.\d+)?%"/);
+
+    // …but after the Azure adaptation, nothing unsigned may reach the API, and
+    // the intended slight slowdown survives as signed-relative values.
+    mockRequestUrl.mockResolvedValue({
+      status: 200,
+      arrayBuffer: new ArrayBuffer(8),
+    });
+    const service = new AzureSpeechService(
+      "key",
+      "eastus",
+      "en-US-JennyNeural",
+    );
+    await service.speak(PIPELINE_SSML);
+    const body = mockRequestUrl.mock.calls[0][0].body as string;
+    expect(body).not.toMatch(/rate="\d/);
+    expect(body).toContain('rate="-2%"');
+    expect(body).toContain('rate="-5%"');
+    // Non-rate prosody (heading volume keyword) is preserved untouched.
+    expect(body).toContain('volume="loud"');
   });
 });
 


### PR DESCRIPTION
This branch carries two independent fixes.

---

## 1) Azure reads headings/emphasis at ~2× speed (closes #56, #77)

**Root cause.** The content pipeline emits one canonical SSML dialect flavoured for AWS Polly, where prosody `rate` is an **absolute** percentage: `rate="95%"` = 0.95× (slightly slower), matching the SSML standard, AWS Polly and Google. **Azure** instead reads a **bare** percentage as **relative**, so `rate="95%"` is treated as `+95%` ≈ **1.95×** ([Microsoft Q&A](https://learn.microsoft.com/en-us/answers/questions/466776/ssml-prosody-tag)). The enhancer wraps headings in `rate="98%"` and italics in `rate="95%"`, so on Azure those spans were synthesized at ~double speed — baked into the MP3 and unique to Azure. `toAzureSsml()` already adapted the incompatible `volume` (dB → %) but left `rate` untouched.

**Fix.** Centralise Azure's SSML quirks in a pure, unit-tested helper `src/service/azureSsml.ts`. `azureProsodyRate()` converts an unsigned absolute percentage to Azure's signed-relative form (`95%` → `-5%`, `98%` → `-2%`); signed values, keywords and multipliers pass through. `adaptProsodyForAzure()` applies rate + volume; `toAzureSsml()` delegates to it (volume behaviour unchanged).

**Tests.** Unit tests for the helpers, a service-level regression test asserting **no unsigned `rate="N%"` reaches Azure**, and a golden test over a representative pipeline-SSML fixture (the real pipeline can't be imported under Jest — it pulls in ESM-only `unified`).

## 2) Play button hold-ring is too thin / low-contrast

While holding the player play button to regenerate, a ring sweeps around it. It reused the shared save-button sweep (3px accent arc at 30% opacity) — but the play button is **itself accent-coloured**, so that's accent-on-accent and barely visible. Gave this button its own ring: a thicker (5px) high-contrast sweep in the on-accent colour plus a faint full track, both behind the opaque button (`z-index: -1`) so only the rim shows and the icon is never covered; the press scale is dropped during the hold to avoid a stacking context. No CSS mask/clip-path, so the Obsidian CSS baseline stays clean.

---

## Type of change
- [x] fix — bug fix (patch)

## Provider / Platform impact
- [x] Azure Speech (fixed); other providers unaffected
- [x] Desktop · [x] Mobile

## Verification
`npm run build` · `lint:check` (scanner parity) · `lint:css` · `npm test` (**200** passing) · `format:check` — all green.

## Checklist
- [x] Build passes
- [x] Lint passes
- [x] Tests pass (200)
- [x] Format passes
- [x] No secrets committed

Closes #56
Closes #77
