### PR TITLE
fix(minimax): native pauses (#85) + fix(settings): provider credentials on Obsidian 1.13+ (#84)

### DIFF
--- a/src/processors/MarkdownToTextProcessor.ts
+++ b/src/processors/MarkdownToTextProcessor.ts
@@ -15,7 +15,7 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import remarkFrontmatter from "remark-frontmatter";
-import type { ProcessorConfig } from "../types/ProcessorTypes";
+import type { ProcessorConfig, PauseStyle } from "../types/ProcessorTypes";
 import { DEFAULT_CONFIG } from "./config/DefaultConfig";
 import { cleanProcessor } from "./pipeline/CleanProcessor";
 import { serializeToText } from "./pipeline/TextSerializer";
@@ -23,19 +23,21 @@ import { titleCaseAcronyms } from "./pipeline/acronyms";
 
 export class MarkdownToTextProcessor {
   private config: ProcessorConfig;
-  private pauseTags: boolean;
+  private pauseStyle: PauseStyle;
 
   constructor(
     config?: Partial<ProcessorConfig>,
-    options: { pauseTags?: boolean } = {},
+    options: { pauseStyle?: PauseStyle } = {},
   ) {
     this.config = {
       ...DEFAULT_CONFIG,
       ...config,
     };
-    // Emit ElevenLabs-style <break> tags for natural structural pauses by
-    // default (supported by all models the plugin offers).
-    this.pauseTags = options.pauseTags ?? true;
+    // Which pause markup to emit is provider-dependent: ElevenLabs understands
+    // `<break>` tags, MiniMax uses `<#x#>`, and engines that read unknown markup
+    // literally (e.g. OpenAI) get plain newline pauses. Default to "none" so an
+    // unspecified provider never has literal markup read aloud (issue #85).
+    this.pauseStyle = options.pauseStyle ?? "none";
   }
 
   /**
@@ -61,8 +63,8 @@ export class MarkdownToTextProcessor {
     };
     cleanProcessor(cleanOptions)(ast);
 
-    // Stage 3: Serialize to spoken text (with structural pause tags)
-    const text = serializeToText(ast, { pauseTags: this.pauseTags });
+    // Stage 3: Serialize to spoken text (with the provider's pause style)
+    const text = serializeToText(ast, { pauseStyle: this.pauseStyle });
 
     // Stage 4: When acronyms should not be spelled out, title-case them so the
     // engine reads them as a word (consistent with the SSML pipeline). Engines

--- a/src/processors/pipeline/TextSerializer.ts
+++ b/src/processors/pipeline/TextSerializer.ts
@@ -2,15 +2,22 @@
  * TextSerializer - Converts a (cleaned) AST to plain spoken text
  *
  * Unlike the SSMLSerializer, this produces text for engines that do not support
- * full SSML (e.g. ElevenLabs). Two pause styles are supported:
+ * full SSML. Structural pauses are emitted in the style the active provider
+ * understands (see PauseStyle):
  *
- * - Newline boundaries (default): block elements are separated by blank lines
- *   so the engine pauses naturally at sentence/paragraph boundaries.
- * - Break tags (`pauseTags: true`): structural boundaries emit ElevenLabs-style
- *   `<break time="x.xs"/>` tags for more deliberate, natural pauses. These tags
- *   are supported by ElevenLabs multilingual_v2 / turbo v2.5 / flash v2.5.
- *   Breaks are only inserted at block boundaries (headings, paragraphs, list
- *   items, horizontal rules) — not per sentence — to keep prosody stable.
+ * - "none" (default): block elements are separated by blank lines so the engine
+ *   pauses naturally at sentence/paragraph boundaries. Used for engines that
+ *   read unknown markup literally (e.g. OpenAI).
+ * - "break-tags": structural boundaries emit ElevenLabs-style
+ *   `<break time="x.xs"/>` tags, supported by ElevenLabs multilingual_v2 /
+ *   turbo v2.5 / flash v2.5.
+ * - "minimax": structural boundaries emit MiniMax's native `<#x#>` pause markers
+ *   (x = seconds). MiniMax does NOT understand `<break>` tags — it would read
+ *   them aloud (issue #85) — and requires that pause markers never appear
+ *   consecutively or at the very start/end, which the post-processing enforces.
+ *
+ * Breaks are only inserted at block boundaries (headings, paragraphs, list
+ * items, horizontal rules) — not per sentence — to keep prosody stable.
  *
  * It is meant to run on a tree that has already passed through the
  * CleanProcessor (links flattened, code/inline-code turned into text, images
@@ -21,29 +28,30 @@
 
 import type { Node, Parent } from "unist";
 import type { Text, Code, InlineCode } from "mdast";
+import type { PauseStyle } from "../../types/ProcessorTypes";
 
 export interface TextSerializerOptions {
-  /** Emit ElevenLabs <break> tags at block boundaries for natural pauses. */
-  pauseTags?: boolean;
+  /** Which pause markup (if any) to emit at block boundaries. Default "none". */
+  pauseStyle?: PauseStyle;
 }
 
 // Pause lengths (seconds) per block type, kept modest to preserve stability.
-const BREAK_HEADING = "0.5s";
-const BREAK_PARAGRAPH = "0.35s";
-const BREAK_LIST_ITEM = "0.2s";
-const BREAK_RULE = "0.8s";
+const BREAK_HEADING = 0.5;
+const BREAK_PARAGRAPH = 0.35;
+const BREAK_LIST_ITEM = 0.2;
+const BREAK_RULE = 0.8;
 
 /**
- * Serialize an AST to spoken text
+ * Serialize an AST to spoken text.
  */
 export function serializeToText(
   tree: Node,
   options: TextSerializerOptions = {},
 ): string {
-  const pauseTags = options.pauseTags ?? false;
-  const raw = serializeNode(tree, pauseTags);
+  const style = options.pauseStyle ?? "none";
+  const raw = serializeNode(tree, style);
 
-  if (pauseTags) {
+  if (style === "break-tags") {
     // Break tags carry the pauses; flatten whitespace to single spaces and
     // merge any consecutive breaks (e.g. paragraph + list-item) into one so
     // stacked pauses don't destabilize the engine's prosody.
@@ -56,6 +64,20 @@ export function serializeToText(
       .trim();
   }
 
+  if (style === "minimax") {
+    // MiniMax `<#x#>` markers carry the pauses. Its rules: markers may not be
+    // consecutive and may not sit at the very start/end (an isolated pause is
+    // ignored, or the second of a pair is dropped), so merge stacks and trim
+    // any leading/trailing markers.
+    return raw
+      .replace(/\s+/g, " ")
+      .replace(/(?:<#[\d.]+#>\s*){2,}/g, "<#0.4#> ")
+      .replace(/^\s*(?:<#[\d.]+#>\s*)+/, "")
+      .replace(/(?:\s*<#[\d.]+#>)+\s*$/, "")
+      .trim();
+  }
+
+  // "none": newline boundaries only.
   return raw
     .replace(/[ \t]+/g, " ") // collapse runs of spaces/tabs
     .replace(/ *\n */g, "\n") // trim spaces around newlines
@@ -63,14 +85,26 @@ export function serializeToText(
     .trim();
 }
 
-function breakTag(time: string): string {
-  return ` <break time="${time}" /> `;
+/** True when the style emits inline pause markup (rather than newlines). */
+function usesMarkers(style: PauseStyle): boolean {
+  return style !== "none";
+}
+
+/** Render a block-boundary pause in the active style. */
+function pauseMarker(style: PauseStyle, seconds: number): string {
+  if (style === "minimax") {
+    return ` <#${seconds}#> `;
+  }
+  // "break-tags"
+  return ` <break time="${seconds}s" /> `;
 }
 
 /**
- * Serialize a single node to text
+ * Serialize a single node to text.
  */
-function serializeNode(node: Node, pauseTags: boolean): string {
+function serializeNode(node: Node, style: PauseStyle): string {
+  const marked = usesMarkers(style);
+
   switch (node.type) {
     case "text":
       return (node as Text).value;
@@ -84,40 +118,44 @@ function serializeNode(node: Node, pauseTags: boolean): string {
     case "heading": {
       // End headings with a sentence stop so the engine pauses, then a
       // structural pause before the following block.
-      const text = serializeChildren(node, pauseTags).trim();
+      const text = serializeChildren(node, style).trim();
       if (!text) {
         return "";
       }
       const stop = /[.!?:]$/.test(text) ? "" : ".";
-      return `${text}${stop}${pauseTags ? breakTag(BREAK_HEADING) : "\n\n"}`;
+      return `${text}${stop}${
+        marked ? pauseMarker(style, BREAK_HEADING) : "\n\n"
+      }`;
     }
 
     case "paragraph":
-      return `${serializeChildren(node, pauseTags)}${
-        pauseTags ? breakTag(BREAK_PARAGRAPH) : "\n\n"
+      return `${serializeChildren(node, style)}${
+        marked ? pauseMarker(style, BREAK_PARAGRAPH) : "\n\n"
       }`;
 
     case "blockquote":
-      return `${serializeChildren(node, pauseTags)}${
-        pauseTags ? breakTag(BREAK_PARAGRAPH) : "\n\n"
+      return `${serializeChildren(node, style)}${
+        marked ? pauseMarker(style, BREAK_PARAGRAPH) : "\n\n"
       }`;
 
     case "listItem":
-      return `${serializeChildren(node, pauseTags).trim()}${
-        pauseTags ? breakTag(BREAK_LIST_ITEM) : "\n"
+      return `${serializeChildren(node, style).trim()}${
+        marked ? pauseMarker(style, BREAK_LIST_ITEM) : "\n"
       }`;
 
     case "list":
-      return `${serializeChildren(node, pauseTags)}${pauseTags ? "" : "\n"}`;
+      return `${serializeChildren(node, style)}${marked ? "" : "\n"}`;
 
     case "tableCell":
-      return `${serializeChildren(node, pauseTags)}, `;
+      return `${serializeChildren(node, style)}, `;
 
     case "tableRow":
-      return `${serializeChildren(node, pauseTags).trim()}${pauseTags ? breakTag(BREAK_LIST_ITEM) : "\n"}`;
+      return `${serializeChildren(node, style).trim()}${
+        marked ? pauseMarker(style, BREAK_LIST_ITEM) : "\n"
+      }`;
 
     case "table":
-      return `${serializeChildren(node, pauseTags)}${pauseTags ? "" : "\n"}`;
+      return `${serializeChildren(node, style)}${marked ? "" : "\n"}`;
 
     case "break":
       return " ";
@@ -125,21 +163,21 @@ function serializeNode(node: Node, pauseTags: boolean): string {
     // Horizontal rules become ssmlBreak in the cleaner; treat as a longer pause.
     case "thematicBreak":
     case "ssmlBreak":
-      return pauseTags ? breakTag(BREAK_RULE) : "\n\n";
+      return marked ? pauseMarker(style, BREAK_RULE) : "\n\n";
 
     default:
       // strong, emphasis, delete, link, root and any other parent: keep text
-      return serializeChildren(node, pauseTags);
+      return serializeChildren(node, style);
   }
 }
 
 /**
- * Serialize the children of a parent node, if any
+ * Serialize the children of a parent node, if any.
  */
-function serializeChildren(node: Node, pauseTags: boolean): string {
+function serializeChildren(node: Node, style: PauseStyle): string {
   if ("children" in node && Array.isArray((node as Parent).children)) {
     return (node as Parent).children
-      .map((child) => serializeNode(child, pauseTags))
+      .map((child) => serializeNode(child, style))
       .join("");
   }
   return "";

--- a/src/service/BaseSpeechService.ts
+++ b/src/service/BaseSpeechService.ts
@@ -19,6 +19,7 @@ import {
   MIN_SKIP_SECONDS,
   MAX_SKIP_SECONDS,
 } from "../settings/VoiceSettings";
+import type { PauseStyle } from "../types/ProcessorTypes";
 
 export abstract class BaseSpeechService implements SpeechProvider {
   protected audio: HTMLAudioElement;
@@ -49,6 +50,10 @@ export abstract class BaseSpeechService implements SpeechProvider {
   // --- Provider-specific members implemented by subclasses ---
 
   abstract readonly inputFormat: "ssml" | "text";
+  // Providers that use structural pause markup override this (ElevenLabs =
+  // "break-tags", MiniMax = "minimax"). Everything else — SSML providers and
+  // engines that read markup literally (OpenAI) — keeps the safe default.
+  readonly textPauseStyle: PauseStyle = "none";
   abstract speak(
     content: string,
     speed?: number,

--- a/src/service/ElevenLabsService.ts
+++ b/src/service/ElevenLabsService.ts
@@ -28,6 +28,8 @@ const MAX_CHUNK_CHARS = 3000;
 
 export class ElevenLabsService extends BaseSpeechService {
   readonly inputFormat = "text" as const;
+  // ElevenLabs multilingual_v2 / turbo v2.5 / flash v2.5 understand <break> tags.
+  readonly textPauseStyle = "break-tags" as const;
 
   private apiKey: string;
   private model: string;

--- a/src/service/MiniMaxSpeechService.ts
+++ b/src/service/MiniMaxSpeechService.ts
@@ -31,6 +31,8 @@ const MAX_CHUNK_CHARS = 3000;
 
 export class MiniMaxSpeechService extends BaseSpeechService {
   readonly inputFormat = "text" as const;
+  // MiniMax uses native `<#x#>` pause markers; it reads `<break>` tags aloud.
+  readonly textPauseStyle = "minimax" as const;
 
   private apiKey: string;
   private groupId: string;

--- a/src/service/SpeechProvider.ts
+++ b/src/service/SpeechProvider.ts
@@ -11,6 +11,7 @@
  */
 
 import type { VoiceSettings, VoiceOption } from "../settings/VoiceSettings";
+import type { PauseStyle } from "../types/ProcessorTypes";
 
 /**
  * Result of validating a provider's credentials
@@ -35,6 +36,14 @@ export interface SpeechProvider {
    * - "text": plain spoken text (ElevenLabs)
    */
   readonly inputFormat: "ssml" | "text";
+
+  /**
+   * For "text" providers, which pause markup the engine understands so the text
+   * pipeline emits the right kind (ElevenLabs `<break>`, MiniMax `<#x#>`, or
+   * newline-only for engines that read markup literally). Irrelevant for "ssml"
+   * providers; defaults to "none".
+   */
+  readonly textPauseStyle: PauseStyle;
 
   /**
    * Synthesize and play the given processed content.

--- a/src/settings/VoiceSettingTab.ts
+++ b/src/settings/VoiceSettingTab.ts
@@ -180,13 +180,19 @@ export class VoiceSettingTab extends PluginSettingTab {
         name: "",
         searchable: false,
         render: (setting) => {
-          const host = setting.settingEl.parentElement;
-          setting.settingEl.remove();
-          if (!host) {
-            return;
-          }
-          this.providerSectionEl = host.createDiv();
-          this.renderActiveProviderSettings(this.providerSectionEl);
+          // Mount the active provider's credential section. On Obsidian 1.13
+          // stable the synthetic row is not yet attached when render() runs, so
+          // setting.settingEl.parentElement is null (it worked in the 1.13
+          // beta) and the whole section silently went missing. Render into the
+          // row element itself instead — it is always valid and is attached to
+          // the tab along with the row — after stripping the default
+          // setting-item chrome. (SettingGroup.listEl would be the natural
+          // container but is @since 1.11, past the 1.7.2 minAppVersion.)
+          const el = setting.settingEl;
+          el.empty();
+          el.removeClass("setting-item");
+          this.providerSectionEl = el;
+          this.renderActiveProviderSettings(el);
         },
       },
     ];

--- a/src/types/ProcessorTypes.ts
+++ b/src/types/ProcessorTypes.ts
@@ -6,6 +6,15 @@ import type { Root } from "mdast";
 import type { VFile } from "vfile";
 
 /**
+ * How structural pauses are emitted for text (non-SSML) providers:
+ * - "none": rely on newline/punctuation boundaries only (no markup) — the safe
+ *   default for engines that read unknown markup literally (e.g. OpenAI).
+ * - "break-tags": ElevenLabs-style `<break time="x.xs"/>` tags.
+ * - "minimax": MiniMax native `<#x#>` pause markers (x = seconds).
+ */
+export type PauseStyle = "none" | "break-tags" | "minimax";
+
+/**
  * Configuration options for the Markdown to SSML processor
  */
 export interface ProcessorConfig {

--- a/src/utils/TextSpeaker.ts
+++ b/src/utils/TextSpeaker.ts
@@ -61,11 +61,17 @@ export class TextSpeaker {
 
     // Plain-text pipeline (ElevenLabs and other non-SSML providers). It also
     // needs the acronym setting so it can title-case acronyms when spell-out is
-    // off, keeping pronunciation consistent with the SSML providers.
-    this.textProcessor = new MarkdownToTextProcessor({
-      ...contentOptions,
-      spellOutAcronyms: this.spellOutAcronyms,
-    });
+    // off, keeping pronunciation consistent with the SSML providers. The pause
+    // style follows the active provider so each engine gets pause markup it
+    // understands (ElevenLabs `<break>`, MiniMax `<#x#>`, others newline-only) —
+    // TextSpeaker is rebuilt on provider change, so this stays in sync.
+    this.textProcessor = new MarkdownToTextProcessor(
+      {
+        ...contentOptions,
+        spellOutAcronyms: this.spellOutAcronyms,
+      },
+      { pauseStyle: this.provider.textPauseStyle },
+    );
   }
 
   async speakText(speed?: number): Promise<void> {

--- a/tests/text-pipeline.unit.test.ts
+++ b/tests/text-pipeline.unit.test.ts
@@ -1,5 +1,9 @@
 import { serializeToText } from "../src/processors/pipeline/TextSerializer";
 import type { Node } from "unist";
+import { ElevenLabsService } from "../src/service/ElevenLabsService";
+import { OpenAiSpeechService } from "../src/service/OpenAiSpeechService";
+import { MiniMaxSpeechService } from "../src/service/MiniMaxSpeechService";
+import { AzureSpeechService } from "../src/service/AzureSpeechService";
 
 // Small mdast builders (the serializer only reads `type`, `value`, `children`).
 const text = (value: string) => ({ type: "text", value });
@@ -12,37 +16,39 @@ const paragraph = (children: unknown[]) => ({ type: "paragraph", children });
 const strong = (children: unknown[]) => ({ type: "strong", children });
 const root = (children: unknown[]) => ({ type: "root", children }) as Node;
 
-describe("Unit Tests - Text Serializer (ElevenLabs plain text)", () => {
-  describe("Plain text output (no pause tags)", () => {
+describe("Unit Tests - Text Serializer (pause styles)", () => {
+  describe('"none" — newline boundaries only', () => {
     test("flattens headings, paragraphs and inline emphasis to words", () => {
       const tree = root([
         heading(1, [text("Title")]),
         paragraph([text("Hello "), strong([text("bold")]), text(" world.")]),
       ]);
 
-      const result = serializeToText(tree, { pauseTags: false });
+      const result = serializeToText(tree, { pauseStyle: "none" });
 
       expect(result).toContain("Title");
       expect(result).toContain("Hello");
       expect(result).toContain("bold");
       expect(result).toContain("world.");
       expect(result).not.toContain("<break");
+      expect(result).not.toContain("<#");
     });
 
     test("adds a sentence stop after a heading without punctuation", () => {
       const tree = root([heading(2, [text("Overview")])]);
-      const result = serializeToText(tree, { pauseTags: false });
+      const result = serializeToText(tree, { pauseStyle: "none" });
       expect(result).toContain("Overview.");
     });
 
-    test("reads code node content verbatim", () => {
-      const tree = root([{ type: "code", value: "const x = 1;" }]) as Node;
-      const result = serializeToText(tree, { pauseTags: false });
-      expect(result).toContain("const x = 1;");
+    test("defaults to 'none' when no style is given", () => {
+      const tree = root([paragraph([text("A.")]), paragraph([text("B.")])]);
+      const result = serializeToText(tree);
+      expect(result).not.toContain("<break");
+      expect(result).not.toContain("<#");
     });
   });
 
-  describe("Natural pause tags", () => {
+  describe('"break-tags" — ElevenLabs', () => {
     test("emits <break> tags at heading and paragraph boundaries", () => {
       const tree = root([
         heading(1, [text("Heading")]),
@@ -50,34 +56,89 @@ describe("Unit Tests - Text Serializer (ElevenLabs plain text)", () => {
         paragraph([text("Second.")]),
       ]);
 
-      const result = serializeToText(tree, { pauseTags: true });
+      const result = serializeToText(tree, { pauseStyle: "break-tags" });
 
       expect(result).toContain('<break time="');
       expect(result).toContain("Heading");
       expect(result).toContain("First.");
       expect(result).toContain("Second.");
-    });
-
-    test("maps horizontal-rule placeholders to a longer pause", () => {
-      const tree = root([
-        paragraph([text("Before.")]),
-        { type: "ssmlBreak", data: { time: "1s" } },
-        paragraph([text("After.")]),
-      ]);
-
-      const result = serializeToText(tree, { pauseTags: true });
-      // Three break tags: paragraph, rule, paragraph
-      expect(
-        (result.match(/<break time="/g) || []).length,
-      ).toBeGreaterThanOrEqual(2);
+      expect(result).not.toContain("<#");
     });
 
     test("keeps word spacing around inline nodes", () => {
       const tree = root([
         paragraph([text("A normal "), strong([text("bold")]), text(" word.")]),
       ]);
-      const result = serializeToText(tree, { pauseTags: true });
+      const result = serializeToText(tree, { pauseStyle: "break-tags" });
       expect(result).toContain("A normal bold word.");
     });
+  });
+
+  describe('"minimax" — native <#x#> markers (issue #85)', () => {
+    test("emits <#x#> markers, never <break> tags", () => {
+      const tree = root([
+        heading(1, [text("Heading")]),
+        paragraph([text("First.")]),
+        paragraph([text("Second.")]),
+      ]);
+
+      const result = serializeToText(tree, { pauseStyle: "minimax" });
+
+      expect(result).toMatch(/<#[\d.]+#>/);
+      // The whole point of #85: no ElevenLabs break tag reaches MiniMax.
+      expect(result).not.toContain("<break");
+      expect(result).toContain("Heading");
+      expect(result).toContain("First.");
+      expect(result).toContain("Second.");
+    });
+
+    test("never places a marker at the very start or end", () => {
+      const tree = root([paragraph([text("Only paragraph.")])]);
+      const result = serializeToText(tree, { pauseStyle: "minimax" });
+      // A single trailing paragraph pause would be at the end → stripped.
+      expect(result).toBe("Only paragraph.");
+    });
+
+    test("merges consecutive markers into one (no back-to-back pauses)", () => {
+      // A rule between two paragraphs would stack paragraph + rule markers.
+      const tree = root([
+        paragraph([text("Before.")]),
+        { type: "ssmlBreak", data: { time: "1s" } },
+        paragraph([text("After.")]),
+      ]);
+      const result = serializeToText(tree, { pauseStyle: "minimax" });
+      expect(result).not.toMatch(/<#[\d.]+#>\s*<#[\d.]+#>/);
+      expect(result).toContain("Before.");
+      expect(result).toContain("After.");
+    });
+  });
+});
+
+describe("Unit Tests - Provider pause-style declarations", () => {
+  test("ElevenLabs uses break tags", () => {
+    const s = new ElevenLabsService("k", "voice", "eleven_multilingual_v2", 1);
+    expect(s.textPauseStyle).toBe("break-tags");
+  });
+
+  test("MiniMax uses its native markers", () => {
+    const s = new MiniMaxSpeechService(
+      "k",
+      "g",
+      "Wise_Woman",
+      "speech-02-hd",
+      "api.minimax.io",
+      1,
+    );
+    expect(s.textPauseStyle).toBe("minimax");
+  });
+
+  test("OpenAI reads markup literally, so it gets no pause markup", () => {
+    const s = new OpenAiSpeechService("k", "alloy", "gpt-4o-mini-tts", 1);
+    expect(s.textPauseStyle).toBe("none");
+  });
+
+  test("an SSML provider defaults to none (unused)", () => {
+    const s = new AzureSpeechService("k", "eastus", "en-US-JennyNeural", 1);
+    expect(s.textPauseStyle).toBe("none");
   });
 });


### PR DESCRIPTION
This branch carries two related fixes.

---

## 1) MiniMax reads out pause tags (closes #85)

The plain-text pipeline always inserted ElevenLabs-style `<break time="x.xs"/>` tags at block boundaries, for **all** text providers. ElevenLabs parses them; **MiniMax reads them aloud**, so blank lines between paragraphs were spoken as "break time 0.35 s". OpenAI has the same limitation and got the tags too.

**Fix — provider-aware pause markup.** Each provider declares a `textPauseStyle` and the serializer emits accordingly:

| Provider | style | Output |
|---|---|---|
| ElevenLabs | `break-tags` | `<break time="0.35s" />` *(unchanged)* |
| **MiniMax** | `minimax` | native `<#0.35#>` markers |
| OpenAI / SSML providers | `none` | plain newline pauses (no markup) |

MiniMax's rules (no consecutive markers, none at the very start/end) are enforced in post-processing. Serializer + provider-declaration unit tests added.

## 2) Provider credential section does not appear on Obsidian 1.13+ (closes #84)

Reported in #84: the settings section for the API key and "Test Credentials" doesn't show — the tab ends at the Player group. Surfaced independently by the **E2E on Obsidian 1.13.4** (now the matrix's `latest`), which failed while 1.8.4 passed.

**Cause.** On 1.13+, Obsidian renders the tab from `getSettingDefinitions()` and the provider section is mounted by a synthetic `render` item into `setting.settingEl.parentElement` — which is **null on 1.13 stable** because the row isn't attached to the tab when `render()` runs (it worked in the 1.13 beta), so the mount was silently skipped. The pre-1.13 `display()` path mounts into the attached tab container, which is why 1.8.4 passed.

**Fix.** Render the section into `setting.settingEl` itself — always valid and attached along with the row — after stripping the setting-item chrome. Attachment-timing-independent and uses no API newer than the 1.7.2 minAppVersion (`SettingGroup.listEl` would be natural but is `@since 1.11`, and disabling the obsidianmd rule is forbidden).

---

## Type of change
- [x] fix — bug fix (patch)

## Verification
- Unit + build + lint (scanner parity) + CSS lint + format: green (**206** unit tests).
- **E2E (desktop) on Obsidian 1.8.4 and 1.13.4: green** — this is the verifying test for the #84 settings fix (the 1.13+ `getSettingDefinitions` path has no DOM under Jest, so it can only be validated in a real Obsidian).

## Provider / Platform impact
- [x] MiniMax fixed; OpenAI improved; ElevenLabs unchanged; SSML providers unaffected
- [x] Settings render fixed on Obsidian 1.13+ (all providers)
- [x] Desktop · [x] Mobile

## How to test
1. `npm run build && npm run lint:check && npm test && npm run format:check` — green.
2. MiniMax: read a note with blank lines between paragraphs → pauses are silent (no "break time…").
3. On Obsidian 1.13+: open Settings → Voice → the provider's API key fields and **Test Credentials** button now appear, and update when you switch provider.

## Checklist
- [x] Build passes
- [x] Lint passes
- [x] Tests pass (206 unit + E2E on 1.8.4 & 1.13.4)
- [x] Format passes
- [x] No secrets committed

Closes #85
Closes #84
